### PR TITLE
Add package list support to Tag model with comprehensive test coverage

### DIFF
--- a/koji_habitude/loader.py
+++ b/koji_habitude/loader.py
@@ -76,10 +76,20 @@ def pretty_yaml(doc, out=sys.stdout, **opts):
 
 
 class NumberedSafeLoader(yaml.SafeLoader):
-    # Clever and simple trick borrowed from augurar
-    # https://stackoverflow.com/questions/13319067/parsing-yaml-return-with-line-number
 
-    # tweaked to only decorate the documents, not every mapping
+    # allowing our anchors to persist across documents
+    def compose_document(self):
+        self.get_event()
+        node = self.compose_node(None, None)
+        self.get_event()
+
+        # the default impl resets self.anchors here
+        # self.anchors = {}
+        return node
+
+    # Clever and simple trick borrowed from augurar, tweaked to only decorate
+    # the documents, not every dict
+    # * https://stackoverflow.com/questions/13319067/parsing-yaml-return-with-line-number
     def construct_document(self, node):
         mapping = super().construct_document(node)
         mapping['__line__'] = node.start_mark.line + 1

--- a/koji_habitude/models/tag.py
+++ b/koji_habitude/models/tag.py
@@ -30,6 +30,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger("koji_habitude.models.tag")
 
 
+def _compare_arches(koji_arches: Optional[str], arches: Optional[List[str]]) -> bool:
+    if koji_arches is None:
+        return arches is None
+    elif arches is None:
+        return False
+    else:
+        return set(koji_arches.split()) == set(arches)
+
+
 @dataclass
 class TagCreate(Change):
     obj: 'Tag'
@@ -399,10 +408,94 @@ class TagRemoveExternalRepo(Change):
         return f"Remove external repo '{self.repo}' from tag '{self.name}'"
 
 
+@dataclass
+class TagPackageListAdd(Change):
+    name: str
+    package: 'PackageEntry'
+
+    def impl_apply(self, session: MultiCallSession):
+        arches = self.package.extra_arches
+        arches = ' '.join(arches) if arches else None
+        return session.packageListAdd(
+            self.name,
+            self.package.name,
+            owner=self.package.owner,
+            block=self.package.block,
+            extra_arches=arches)
+
+    def explain(self) -> str:
+        return f"Add package '{self.package.name}' to tag '{self.name}'"
+
+
+@dataclass
+class TagPackageListBlock(Change):
+    name: str
+    package: str
+
+    def impl_apply(self, session: MultiCallSession):
+        return session.packageListBlock(self.name, self.package, force=True)
+
+    def explain(self) -> str:
+        return f"Block package '{self.package}' in tag '{self.name}'"
+
+
+@dataclass
+class TagPackageListUnblock(Change):
+    name: str
+    package: str
+
+    def impl_apply(self, session: MultiCallSession):
+        return session.packageListUnblock(self.name, self.package, force=True)
+
+    def explain(self) -> str:
+        return f"Unblock package '{self.package}' in tag '{self.name}'"
+
+
+@dataclass
+class TagPackageListSetOwner(Change):
+    name: str
+    package: str
+    owner: str
+
+    def impl_apply(self, session: MultiCallSession):
+        return session.packageListSetOwner(self.name, self.package, self.owner, force=True)
+
+    def explain(self) -> str:
+        return f"Set owner for package '{self.package}' in tag '{self.name}' to '{self.owner}'"
+
+
+@dataclass
+class TagPackageListSetArches(Change):
+    name: str
+    package: str
+    arches: List[str]
+
+    def impl_apply(self, session: MultiCallSession):
+        arches = self.package.extra_arches
+        arches = ' '.join(arches) if arches else None
+        return session.packageListSetArches(self.name, self.package, arches, force=True)
+
+    def explain(self) -> str:
+        return f"Set extra_arches for package '{self.package}' in tag '{self.name}' to '{self.arches}'"
+
+
+@dataclass
+class TagPackageListRemove(Change):
+    name: str
+    package: str
+
+    def impl_apply(self, session: MultiCallSession):
+        return session.packageListRemove(self.name, self.package, force=True)
+
+    def explain(self) -> str:
+        return f"Remove package '{self.package}' from tag '{self.name}'"
+
+
 class TagChangeReport(ChangeReport):
 
     def impl_read(self, session: MultiCallSession):
         self._taginfo: VirtualCall = self.obj.query_exists(session)
+        self._packages: VirtualCall = None
         self._groups: VirtualCall = None
         self._inheritance: VirtualCall = None
         self._external_repos: VirtualCall = None
@@ -414,6 +507,7 @@ class TagChangeReport(ChangeReport):
         if self._taginfo.result is None:
             return
 
+        self._packages = session.listPackages(tagID=self.obj.name)
         self._groups = session.getTagGroups(self.obj.name, inherit=False, incl_blocked=True)
         self._inheritance = session.getInheritanceData(self.obj.name)
         self._external_repos = session.getTagExternalRepos(tag_info=self.obj.name)
@@ -442,6 +536,8 @@ class TagChangeReport(ChangeReport):
                 yield TagAddInheritance(self.obj.name, parent)
             for repo in self.obj.external_repos:
                 yield TagAddExternalRepo(self.obj.name, repo)
+            for package in self.obj.packages:
+                yield TagPackageListAdd(self.obj.name, package)
             return
 
         if info['locked'] != self.obj.locked:
@@ -459,9 +555,33 @@ class TagChangeReport(ChangeReport):
         if info['extra'] != self.obj.extras:
             yield TagSetExtras(self.obj.name, self.obj.extras)
 
+        yield from self._compare_packages()
         yield from self._compare_groups()
         yield from self._compare_inheritance()
         yield from self._compare_external_repos()
+
+
+    def _compare_packages(self):
+        koji_pkgs = {pkg['package_name']: pkg for pkg in self._packages.result}
+        for package in self.obj.packages:
+            if package.name not in koji_pkgs:
+                yield TagPackageListAdd(self.obj.name, package)
+            else:
+                koji_pkg = koji_pkgs[package.name]
+                if koji_pkg['blocked'] != package.block:
+                    if package.block:
+                        yield TagPackageListBlock(self.obj.name, package.name)
+                    else:
+                        yield TagPackageListUnblock(self.obj.name, package.name)
+                if koji_pkg['owner_name'] != package.owner:
+                    yield TagPackageListSetOwner(self.obj.name, package.name, package.owner)
+                if not _compare_arches(koji_pkg['extra_arches'], package.extra_arches):
+                    yield TagPackageListSetArches(self.obj.name, package.name, package.extra_arches)
+
+        if self.obj.exact_packages:
+            for package_name in koji_pkgs:
+                if package_name not in self.obj.packages:
+                    yield TagPackageListRemove(self.obj.name, package_name)
 
 
     def _compare_inheritance(self):
@@ -611,6 +731,17 @@ class TagGroup(SubModel):
     exact_packages: bool = Field(alias='exact-packages', default=False)
 
 
+class PackageEntry(SubModel):
+
+    name: str = Field(alias='name')
+    block: bool = Field(alias='blocked', default=False)
+    owner: Optional[str] = Field(alias='owner', default=None)
+    extra_arches: Optional[List[str]] = Field(alias='extra-arches', default=None)
+
+    def key(self) -> BaseKey:
+        return ('package', self.name)
+
+
 class InheritanceLink(SubModel):
 
     name: str = Field(alias='name')
@@ -692,6 +823,27 @@ def _simplified_link(data: Any) -> Any:
     return data
 
 
+def _simplified_packages(data: Any) -> Any:
+    """
+    we allow the packages field to be specified in a simplified manner, as a
+    list of strings or a list of dictionaries. If it's a string, the value is
+    considered to be the name of the package.
+    """
+
+    if isinstance(data, list):
+        data = [{'name': data}]
+
+    elif isinstance(data, list):
+        fixed = List[Dict[str, Any]] = []
+        for item in data:
+            if isinstance(item, str):
+                item = {'name': item}
+            fixed.append(item)
+        data = fixed
+
+    return data
+
+
 class Tag(BaseObject):
     """
     Koji tag object model.
@@ -711,6 +863,9 @@ class Tag(BaseObject):
 
     inheritance: List[InheritanceLink] = Field(alias='inheritance', default_factory=list)
     external_repos: List[ExternalRepoLink] = Field(alias='external-repos', default_factory=list)
+
+    packages: List[PackageEntry] = Field(alias='packages', default_factory=list)
+    exact_packages: bool = Field(alias='exact-packages', default=False)
 
     _auto_split: ClassVar[bool] = True
     _is_split: bool = False
@@ -785,6 +940,12 @@ class Tag(BaseObject):
         return _simplified_link(data)
 
 
+    @field_validator('packages', mode='before')
+    @classmethod
+    def convert_packages_from_simplified(cls, data: Any) -> Any:
+        return _simplified_packages(data)
+
+
     def split(self) -> 'Tag':
         # normally a split only creates the object by name, and we worry about doing
         # full configuration in a separate step. For tag we'll do a full creation in
@@ -826,6 +987,10 @@ class Tag(BaseObject):
         # Check for external repository dependencies
         for ext_repo in self.external_repos:
             deps.append(ext_repo.key())
+
+        for package in self.packages:
+            if package.owner:
+                deps.append(('user', package.owner))
 
         return deps
 

--- a/koji_habitude/models/tag.py
+++ b/koji_habitude/models/tag.py
@@ -11,11 +11,10 @@ AI-Assistant: Claude 3.5 Sonnet via Cursor
 
 from dataclasses import dataclass
 import logging
-from typing import (
-    Any, ClassVar, Dict, List, Literal, Optional, Sequence, TYPE_CHECKING,
-)
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Sequence, TYPE_CHECKING
 
 from pydantic import Field, field_validator, model_validator
+
 from koji import ClientSession, MultiCallNotReady, MultiCallSession, VirtualCall
 
 from .base import BaseKey, BaseObject, SubModel
@@ -571,7 +570,7 @@ class TagChangeReport(ChangeReport):
                         yield TagPackageListBlock(self.obj.name, package.name)
                     else:
                         yield TagPackageListUnblock(self.obj.name, package.name)
-                if koji_pkg['owner_name'] != package.owner:
+                if koji_pkg['owner_name'] != package.owner and package.owner is not None:
                     yield TagPackageListSetOwner(self.obj.name, package.name, package.owner)
                 if not _compare_arches(koji_pkg['extra_arches'], package.extra_arches):
                     yield TagPackageListSetArches(self.obj.name, package.name, package.extra_arches)

--- a/koji_habitude/models/tag.py
+++ b/koji_habitude/models/tag.py
@@ -940,6 +940,17 @@ class Tag(BaseObject):
         return data
 
 
+    @field_validator('packages', mode='after')
+    @classmethod
+    def merge_packages(cls, data: Any) -> Any:
+        seen = {}
+        for package in data:
+            if package.name in seen:
+                logger.warning(f"Duplicate package {package.name}, overriding with new value")
+            seen[package.name] = package
+        return list(seen.values())
+
+
     def split(self) -> 'Tag':
         # normally a split only creates the object by name, and we worry about doing
         # full configuration in a separate step. For tag we'll do a full creation in

--- a/koji_habitude/models/tag.py
+++ b/koji_habitude/models/tag.py
@@ -11,10 +11,8 @@ AI-Assistant: Claude 3.5 Sonnet via Cursor
 
 from dataclasses import dataclass
 import logging
-from pyexpat import features
 from typing import (
     Any, ClassVar, Dict, List, Literal, Optional, Sequence, TYPE_CHECKING,
-    Union,
 )
 
 from pydantic import Field, field_validator, model_validator
@@ -421,7 +419,8 @@ class TagPackageListAdd(Change):
             self.package.name,
             owner=self.package.owner,
             block=self.package.block,
-            extra_arches=arches)
+            extra_arches=arches,
+            force=True)
 
     def explain(self) -> str:
         return f"Add package '{self.package.name}' to tag '{self.name}'"

--- a/tests/data/demo/gnutella.yml
+++ b/tests/data/demo/gnutella.yml
@@ -3,11 +3,35 @@ type: product
 name: gnutella
 
 ---
+type: vars
+x-gnutella-1_0-pkglist: &gnutella-1_0-pkglist
+    - gnutella-cobol
+    - gnutella-core
+    - gnutella-plugins
+    - gnutella-gui
+    - gnutella-daemon
+    - gnutella-daemon-plugins
+    - gnutella-daemon-plugins-gui
+
+x-gnutella-2_0-pkglist: &gnutella-2_0-pkglist
+    - name: gnutella-cobol
+      blocked: true
+    - gnutella-ai
+    - gnutella-ai-plugins
+    - gnutella-ai-gui
+    - gnutella-ai-daemon
+    - gnutella-ai-daemon-plugins
+    - gnutella-ai-daemon-plugins-gui
+
+
+---
 type: gnutella-version
 version: "1.0"
 platforms:
   - fedora-40
   - almalinux-9
+packages: *gnutella-1_0-pkglist
+
 
 ---
 type: gnutella-version
@@ -15,6 +39,8 @@ version: "1.1"
 platforms:
   - fedora-40
   - almalinux-9
+packages: *gnutella-1_0-pkglist
+
 
 ---
 type: gnutella-version
@@ -25,5 +51,7 @@ arches:
 platforms:
   - fedora-42
   - almalinux-10
+packages_merge: [*gnutella-1_0-pkglist, *gnutella-2_0-pkglist]
+
 
 # The end.

--- a/tests/data/demo/product.yml
+++ b/tests/data/demo/product.yml
@@ -81,6 +81,45 @@ content: |
     name: {{ g.basetag }}
     locked: True
     permission: admin
+    packages:
+    {% if packages is defined and packages %}
+    {% for package in packages %}
+      {% if package is mapping %}
+      - name: {{ package.get('name') }}
+        {% if package.get('owner') is not none %}
+        owner: {{ package.get('owner') }}
+        {% endif %}
+        {% if package.get('blocked') is not none %}
+        blocked: {{ package.get('blocked') }}
+        {% endif %}
+        {% if package.get('extra-arches') is not none %}
+        extra-arches: {{ package.get('extra-arches') }}
+        {% endif %}
+      {% else %}
+      - {{ package }}
+      {% endif %}
+    {% endfor %}
+    {% endif %}
+    {% if packages_merge is defined and packages_merge %}
+    {% for package_list in packages_merge %}
+    {% for package in package_list %}
+      {% if package is mapping %}
+      - name: {{ package.get('name') }}
+        {% if package.get('owner') is not none %}
+        owner: {{ package.get('owner') }}
+        {% endif %}
+        {% if package.get('blocked') is not none %}
+        blocked: {{ package.get('blocked') }}
+        {% endif %}
+        {% if package.get('extra-arches') is not none %}
+        extra-arches: {{ package.get('extra-arches') }}
+        {% endif %}
+      {% else %}
+      - {{ package }}
+      {% endif %}
+    {% endfor %}
+    {% endfor %}
+    {% endif %}
 
     ---
     type: target

--- a/tests/data/demo/vars.yml
+++ b/tests/data/demo/vars.yml
@@ -1,0 +1,4 @@
+---
+type: template
+name: vars
+content: '# just defining some vars'

--- a/tests/test_models/test_tag.py
+++ b/tests/test_models/test_tag.py
@@ -541,5 +541,251 @@ class TestTagModel(unittest.TestCase):
 
         self.assertIn('Groups must be a dictionary or list', str(context.exception))
 
+    def test_tag_packages_simple_string_list(self):
+        """
+        Test Tag creation with packages as a simple list of strings.
+        """
+
+        data = {
+            'type': 'tag',
+            'name': 'test-tag',
+            'packages': ['package1', 'package2', 'package3']
+        }
+        tag = Tag.from_dict(data)
+
+        # Check that packages were converted to PackageEntry objects
+        self.assertEqual(len(tag.packages), 3)
+
+        # Check first package
+        self.assertEqual(tag.packages[0].name, 'package1')
+        self.assertEqual(tag.packages[0].block, False)
+        self.assertEqual(tag.packages[0].owner, None)
+        self.assertEqual(tag.packages[0].extra_arches, None)
+
+        # Check second package
+        self.assertEqual(tag.packages[1].name, 'package2')
+        self.assertEqual(tag.packages[1].block, False)
+        self.assertEqual(tag.packages[1].owner, None)
+        self.assertEqual(tag.packages[1].extra_arches, None)
+
+        # Check third package
+        self.assertEqual(tag.packages[2].name, 'package3')
+        self.assertEqual(tag.packages[2].block, False)
+        self.assertEqual(tag.packages[2].owner, None)
+        self.assertEqual(tag.packages[2].extra_arches, None)
+
+    def test_tag_packages_dict_format(self):
+        """
+        Test Tag creation with packages in dict format with full specifications.
+        """
+
+        data = {
+            'type': 'tag',
+            'name': 'test-tag',
+            'packages': [
+                {'name': 'package1', 'owner': 'user1'},
+                {'name': 'package2', 'owner': 'user2', 'blocked': True},
+                {'name': 'package3', 'owner': 'user3', 'extra-arches': ['i686', 'ppc64le']}
+            ]
+        }
+        tag = Tag.from_dict(data)
+
+        # Check packages structure
+        self.assertEqual(len(tag.packages), 3)
+
+        # Check first package (with owner)
+        self.assertEqual(tag.packages[0].name, 'package1')
+        self.assertEqual(tag.packages[0].owner, 'user1')
+        self.assertEqual(tag.packages[0].block, False)
+        self.assertEqual(tag.packages[0].extra_arches, None)
+
+        # Check second package (with owner and blocked)
+        self.assertEqual(tag.packages[1].name, 'package2')
+        self.assertEqual(tag.packages[1].owner, 'user2')
+        self.assertEqual(tag.packages[1].block, True)
+        self.assertEqual(tag.packages[1].extra_arches, None)
+
+        # Check third package (with owner and extra-arches)
+        self.assertEqual(tag.packages[2].name, 'package3')
+        self.assertEqual(tag.packages[2].owner, 'user3')
+        self.assertEqual(tag.packages[2].block, False)
+        self.assertEqual(tag.packages[2].extra_arches, ['i686', 'ppc64le'])
+
+    def test_tag_packages_mixed_format(self):
+        """
+        Test Tag creation with packages mixing strings and dict objects.
+        """
+
+        data = {
+            'type': 'tag',
+            'name': 'test-tag',
+            'packages': [
+                'package1',  # Simple string
+                {'name': 'package2', 'owner': 'user2'},  # Dict with owner
+                'package3',  # Simple string
+                {'name': 'package4', 'owner': 'user4', 'blocked': True}  # Dict with owner and blocked
+            ]
+        }
+        tag = Tag.from_dict(data)
+
+        # Check that packages were processed correctly
+        self.assertEqual(len(tag.packages), 4)
+
+        # Check string conversion (package1)
+        self.assertEqual(tag.packages[0].name, 'package1')
+        self.assertEqual(tag.packages[0].owner, None)
+        self.assertEqual(tag.packages[0].block, False)
+
+        # Check dict with owner (package2)
+        self.assertEqual(tag.packages[1].name, 'package2')
+        self.assertEqual(tag.packages[1].owner, 'user2')
+        self.assertEqual(tag.packages[1].block, False)
+
+        # Check string conversion (package3)
+        self.assertEqual(tag.packages[2].name, 'package3')
+        self.assertEqual(tag.packages[2].owner, None)
+        self.assertEqual(tag.packages[2].block, False)
+
+        # Check dict with owner and blocked (package4)
+        self.assertEqual(tag.packages[3].name, 'package4')
+        self.assertEqual(tag.packages[3].owner, 'user4')
+        self.assertEqual(tag.packages[3].block, True)
+
+    def test_tag_packages_empty_list(self):
+        """
+        Test Tag creation with empty packages list.
+        """
+
+        data = {
+            'type': 'tag',
+            'name': 'test-tag',
+            'packages': []
+        }
+        tag = Tag.from_dict(data)
+
+        # Check that packages is empty
+        self.assertEqual(len(tag.packages), 0)
+
+    def test_tag_packages_default_empty(self):
+        """
+        Test that packages defaults to empty list when not specified.
+        """
+
+        data = {
+            'type': 'tag',
+            'name': 'test-tag'
+        }
+        tag = Tag.from_dict(data)
+
+        # Check that packages defaults to empty
+        self.assertEqual(len(tag.packages), 0)
+        self.assertEqual(tag.packages, [])
+
+    def test_tag_packages_with_extra_arches(self):
+        """
+        Test Tag creation with packages that have extra-arches specified.
+        """
+
+        data = {
+            'type': 'tag',
+            'name': 'test-tag',
+            'packages': [
+                {'name': 'package1', 'owner': 'user1', 'extra-arches': ['x86_64', 'i686']},
+                {'name': 'package2', 'owner': 'user2', 'extra-arches': ['ppc64le']}
+            ]
+        }
+        tag = Tag.from_dict(data)
+
+        # Check first package with multiple arches
+        self.assertEqual(tag.packages[0].name, 'package1')
+        self.assertEqual(tag.packages[0].owner, 'user1')
+        self.assertEqual(tag.packages[0].extra_arches, ['x86_64', 'i686'])
+
+        # Check second package with single arch
+        self.assertEqual(tag.packages[1].name, 'package2')
+        self.assertEqual(tag.packages[1].owner, 'user2')
+        self.assertEqual(tag.packages[1].extra_arches, ['ppc64le'])
+
+    def test_tag_packages_blocked_flag(self):
+        """
+        Test Tag creation with packages that have blocked flag set.
+        """
+
+        data = {
+            'type': 'tag',
+            'name': 'test-tag',
+            'packages': [
+                {'name': 'package1', 'owner': 'user1', 'blocked': False},
+                {'name': 'package2', 'owner': 'user2', 'blocked': True},
+                {'name': 'package3', 'owner': 'user3'}  # blocked defaults to False
+            ]
+        }
+        tag = Tag.from_dict(data)
+
+        # Check first package (explicitly not blocked)
+        self.assertEqual(tag.packages[0].name, 'package1')
+        self.assertEqual(tag.packages[0].block, False)
+
+        # Check second package (blocked)
+        self.assertEqual(tag.packages[1].name, 'package2')
+        self.assertEqual(tag.packages[1].block, True)
+
+        # Check third package (default not blocked)
+        self.assertEqual(tag.packages[2].name, 'package3')
+        self.assertEqual(tag.packages[2].block, False)
+
+    def test_tag_dependency_keys_with_package_owners(self):
+        """
+        Test Tag dependency resolution includes package owners.
+        """
+
+        data = {
+            'type': 'tag',
+            'name': 'test-tag',
+            'packages': [
+                {'name': 'package1', 'owner': 'user1'},
+                {'name': 'package2', 'owner': 'user2'},
+                {'name': 'package3'}  # No owner
+            ]
+        }
+        tag = Tag.from_dict(data)
+
+        deps = tag.dependency_keys()
+        expected = [
+            ('user', 'user1'),
+            ('user', 'user2')
+        ]
+        self.assertEqual(deps, expected)
+
+    def test_tag_dependency_keys_with_all_dependencies(self):
+        """
+        Test Tag dependency resolution with packages, inheritance, and external repos.
+        """
+
+        data = {
+            'type': 'tag',
+            'name': 'test-tag',
+            'packages': [
+                {'name': 'package1', 'owner': 'user1'},
+                {'name': 'package2', 'owner': 'user2'}
+            ],
+            'inheritance': [
+                {'name': 'parent1', 'priority': 10}
+            ],
+            'external-repos': [
+                {'name': 'repo1', 'priority': 30}
+            ]
+        }
+        tag = Tag.from_dict(data)
+
+        deps = tag.dependency_keys()
+        expected = [
+            ('tag', 'parent1'),
+            ('external-repo', 'repo1'),
+            ('user', 'user1'),
+            ('user', 'user2')
+        ]
+        self.assertEqual(deps, expected)
+
 
 # The end.

--- a/tests/test_processor_models/test_tag.py
+++ b/tests/test_processor_models/test_tag.py
@@ -33,7 +33,7 @@ def create_test_tag(name: str, locked: bool = False, permission: str = None,
                    arches: list = None, maven_support: bool = False,
                    maven_include_all: bool = False, extras: dict = None,
                    groups: dict = None, inheritance: list = None,
-                   external_repos: list = None) -> Tag:
+                   external_repos: list = None, packages: list = None) -> Tag:
     """
     Create a test tag with the specified parameters.
 
@@ -48,6 +48,7 @@ def create_test_tag(name: str, locked: bool = False, permission: str = None,
         groups: Tag groups dict (default empty dict)
         inheritance: List of inheritance links (default empty list)
         external_repos: List of external repo links (default empty list)
+        packages: List of package entries (default empty list)
 
     Returns:
         Tag object for testing
@@ -63,6 +64,7 @@ def create_test_tag(name: str, locked: bool = False, permission: str = None,
         groups=groups or {},
         inheritance=inheritance or [],
         external_repos=external_repos or [],
+        packages=packages or [],
         filename='test.yaml',
         lineno=1
     )
@@ -97,6 +99,9 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         get_tag_post_mock = Mock()
         get_tag_post_mock.return_value = None
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []
 
@@ -113,6 +118,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         set_extras_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -134,6 +140,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         get_tag_mock.assert_called_once_with('new-tag', strict=False)
         get_tag_post_mock.assert_called_once_with('new-tag', strict=False)
         # When tag doesn't exist, deferred calls are not made
+        list_packages_mock.assert_not_called()
         get_groups_mock.assert_not_called()
         get_inheritance_mock.assert_not_called()
         get_external_repos_mock.assert_not_called()
@@ -167,6 +174,9 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         get_tag_post_mock = Mock()
         get_tag_post_mock.return_value = None
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []
 
@@ -198,6 +208,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         add_external_repo_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -227,6 +238,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         get_tag_mock.assert_called_once_with('complex-tag', strict=False)
         get_tag_post_mock.assert_called_once_with('complex-tag', strict=False)
         # When tag doesn't exist, deferred calls are not made
+        list_packages_mock.assert_not_called()
         get_groups_mock.assert_not_called()
         get_inheritance_mock.assert_not_called()
         get_external_repos_mock.assert_not_called()
@@ -267,6 +279,9 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []
 
@@ -280,6 +295,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         set_locked_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -296,6 +312,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertTrue(result)  # Should process 1 object
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
         set_locked_mock.assert_called_once_with('existing-tag', locked=True)
 
@@ -317,6 +334,9 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []
 
@@ -330,6 +350,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         set_permission_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -346,6 +367,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertTrue(result)  # Should process 1 object
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
         set_permission_mock.assert_called_once_with('existing-tag', perm='admin')
 
@@ -367,6 +389,9 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []
 
@@ -380,6 +405,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         set_arches_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -396,6 +422,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertTrue(result)  # Should process 1 object
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
         set_arches_mock.assert_called_once_with('existing-tag', arches='x86_64 aarch64')
 
@@ -417,6 +444,9 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []
 
@@ -430,6 +460,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         set_maven_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -446,6 +477,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertTrue(result)  # Should process 1 object
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
         set_maven_mock.assert_called_once_with('existing-tag', maven_support=True, maven_include_all=True)
 
@@ -467,6 +499,9 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []
 
@@ -477,6 +512,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         get_external_repos_mock.return_value = []
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -493,6 +529,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         get_inheritance_mock.assert_called_once_with('existing-tag')
         get_external_repos_mock.assert_called_once_with(tag_info='existing-tag')
@@ -620,6 +657,9 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []  # No groups currently
 
@@ -636,6 +676,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         add_group_pkg_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -654,6 +695,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         add_group_mock.assert_called_once_with('existing-tag', 'build', description=None, block=False, force=True)
         add_group_pkg_mock.assert_called_once_with('existing-tag', 'build', 'package1', block=False, force=True)
@@ -677,6 +719,9 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         # Mock existing group with different properties
         get_groups_mock = Mock()
         get_groups_mock.return_value = [{
@@ -696,6 +741,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         update_group_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -713,6 +759,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should update group because block status differs
         update_group_mock.assert_called_once_with('existing-tag', 'build', description=None, block=False, force=True)
@@ -738,6 +785,9 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         # Mock existing group that should be removed
         get_groups_mock = Mock()
         get_groups_mock.return_value = [{
@@ -757,6 +807,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         remove_group_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -774,6 +825,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should remove the group because exact_groups=True and group not in desired state
         remove_group_mock.assert_called_once_with('existing-tag', 'build')
@@ -797,6 +849,9 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         # Mock existing group with only one package
         get_groups_mock = Mock()
         get_groups_mock.return_value = [{
@@ -816,6 +871,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         add_group_pkg_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -833,6 +889,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should add the missing package
         add_group_pkg_mock.assert_called_once_with('existing-tag', 'build', 'package2', block=False, force=True)
@@ -856,6 +913,9 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         # Mock existing group with package that has different block status
         get_groups_mock = Mock()
         get_groups_mock.return_value = [{
@@ -875,6 +935,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         update_group_pkg_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -892,6 +953,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should update the package because block status differs
         update_group_pkg_mock.assert_called_once_with('existing-tag', 'build', 'package1', block=True, force=True)
@@ -917,6 +979,9 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         # Mock existing group with extra package that should be removed
         get_groups_mock = Mock()
         get_groups_mock.return_value = [{
@@ -939,6 +1004,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         remove_group_pkg_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -956,6 +1022,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should remove the extra package because exact_packages=True
         remove_group_pkg_mock.assert_called_once_with('existing-tag', 'build', 'package2')
@@ -987,6 +1054,9 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         # Mock existing group with packages that need various changes
         get_groups_mock = Mock()
         get_groups_mock.return_value = [{
@@ -1016,6 +1086,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         remove_group_pkg2_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -1035,6 +1106,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
 
         # Should add new package3
@@ -1071,6 +1143,9 @@ class TestProcessorTagDependencies(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []
 
@@ -1084,6 +1159,7 @@ class TestProcessorTagDependencies(MulticallMocking, TestCase):
         add_inheritance_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -1126,6 +1202,9 @@ class TestProcessorTagDependencies(MulticallMocking, TestCase):
             'extra': {}
         }
 
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
         get_groups_mock = Mock()
         get_groups_mock.return_value = []
 
@@ -1139,6 +1218,7 @@ class TestProcessorTagDependencies(MulticallMocking, TestCase):
         add_external_repo_mock.return_value = None
 
         self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
@@ -1297,6 +1377,698 @@ class TestProcessorTagDependencies(MulticallMocking, TestCase):
         self.assertEqual(len(inheritance_data), 1)
         self.assertEqual(inheritance_data[0]['parent_id'], 1)  # parent tag ID
         self.assertEqual(inheritance_data[0]['priority'], 10)
+
+
+class TestProcessorTagPackages(MulticallMocking, TestCase):
+    """
+    Test Tag processor integration for package list management.
+
+    Covers adding, updating, blocking/unblocking, and removing packages from tags.
+    """
+
+    def test_add_package_to_tag(self):
+        """Test adding a single package to an existing tag."""
+
+        tag = create_test_tag(
+            'existing-tag',
+            packages=[{'name': 'my-package', 'owner': 'testuser'}])
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        # Mock the getTag call to return existing tag
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = {
+            'name': 'existing-tag',
+            'locked': False,
+            'perm': None,
+            'arches': '',
+            'maven_support': False,
+            'maven_include_all': False,
+            'extra': {}
+        }
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []  # No packages currently
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        add_package_mock = Mock()
+        add_package_mock.return_value = None
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+        self.queue_client_response('packageListAdd', add_package_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
+        add_package_mock.assert_called_once_with(
+            'existing-tag',
+            'my-package',
+            owner='testuser',
+            block=False,
+            extra_arches=None
+        )
+
+    def test_add_package_with_extra_arches(self):
+        """Test adding a package with extra_arches specified."""
+
+        tag = create_test_tag('existing-tag', packages=[{'name': 'my-package', 'owner': 'testuser', 'extra-arches': ['i686', 'ppc64le']}])
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        # Mock the getTag call to return existing tag
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = {
+            'name': 'existing-tag',
+            'locked': False,
+            'perm': None,
+            'arches': '',
+            'maven_support': False,
+            'maven_include_all': False,
+            'extra': {}
+        }
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        add_package_mock = Mock()
+        add_package_mock.return_value = None
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+        self.queue_client_response('packageListAdd', add_package_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        add_package_mock.assert_called_once_with(
+            'existing-tag',
+            'my-package',
+            owner='testuser',
+            block=False,
+            extra_arches='i686 ppc64le'
+        )
+
+    def test_block_package(self):
+        """Test blocking an existing unblocked package."""
+
+        tag = create_test_tag('existing-tag', packages=[{'name': 'my-package', 'owner': 'testuser', 'blocked': True}])
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        # Mock the getTag call to return existing tag
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = {
+            'name': 'existing-tag',
+            'locked': False,
+            'perm': None,
+            'arches': '',
+            'maven_support': False,
+            'maven_include_all': False,
+            'extra': {}
+        }
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = [{
+            'package_name': 'my-package',
+            'owner_name': 'testuser',
+            'blocked': False,  # Currently not blocked
+            'extra_arches': None
+        }]
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        block_package_mock = Mock()
+        block_package_mock.return_value = None
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+        self.queue_client_response('packageListBlock', block_package_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        list_packages_mock.assert_called_once_with(tagID='existing-tag')
+        block_package_mock.assert_called_once_with('existing-tag', 'my-package', force=True)
+
+    def test_unblock_package(self):
+        """Test unblocking a previously blocked package."""
+
+        tag = create_test_tag(
+            'existing-tag',
+            packages=[{'name': 'my-package', 'owner': 'testuser', 'blocked': False}])
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        # Mock the getTag call to return existing tag
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = {
+            'name': 'existing-tag',
+            'locked': False,
+            'perm': None,
+            'arches': '',
+            'maven_support': False,
+            'maven_include_all': False,
+            'extra': {}
+        }
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = [{
+            'package_name': 'my-package',
+            'owner_name': 'testuser',
+            'blocked': True,  # Currently blocked
+            'extra_arches': None
+        }]
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        unblock_package_mock = Mock()
+        unblock_package_mock.return_value = None
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+        self.queue_client_response('packageListUnblock', unblock_package_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        unblock_package_mock.assert_called_once_with('existing-tag', 'my-package', force=True)
+
+    def test_update_package_owner(self):
+        """Test changing the owner of an existing package."""
+
+        tag = create_test_tag('existing-tag', packages=[{'name': 'my-package', 'owner': 'newuser'}])
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        # Mock the getTag call to return existing tag
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = {
+            'name': 'existing-tag',
+            'locked': False,
+            'perm': None,
+            'arches': '',
+            'maven_support': False,
+            'maven_include_all': False,
+            'extra': {}
+        }
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = [{
+            'package_name': 'my-package',
+            'owner_name': 'olduser',  # Different owner
+            'blocked': False,
+            'extra_arches': None
+        }]
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        set_owner_mock = Mock()
+        set_owner_mock.return_value = None
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+        self.queue_client_response('packageListSetOwner', set_owner_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        set_owner_mock.assert_called_once_with('existing-tag', 'my-package', 'newuser', force=True)
+
+    def test_update_package_extra_arches(self):
+        """Test changing extra_arches of an existing package."""
+
+        tag = create_test_tag('existing-tag', packages=[{'name': 'my-package', 'owner': 'testuser', 'extra-arches': ['i686']}])
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        # Mock the getTag call to return existing tag
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = {
+            'name': 'existing-tag',
+            'locked': False,
+            'perm': None,
+            'arches': '',
+            'maven_support': False,
+            'maven_include_all': False,
+            'extra': {}
+        }
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = [{
+            'package_name': 'my-package',
+            'owner_name': 'testuser',
+            'blocked': False,
+            'extra_arches': None  # Different from desired state
+        }]
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        set_arches_mock = Mock()
+        set_arches_mock.return_value = None
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+        self.queue_client_response('packageListSetArches', set_arches_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        # koji call expects arches to be a space separated string
+        set_arches_mock.assert_called_once_with('existing-tag', 'my-package', 'i686', force=True)
+
+    def test_remove_package_with_exact_packages(self):
+        """Test removing packages not in desired state when exact_packages=True."""
+
+        tag = create_test_tag('existing-tag', packages=[{'name': 'keep-package', 'owner': 'testuser'}])
+        tag.exact_packages = True
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        # Mock the getTag call to return existing tag
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = {
+            'name': 'existing-tag',
+            'locked': False,
+            'perm': None,
+            'arches': '',
+            'maven_support': False,
+            'maven_include_all': False,
+            'extra': {}
+        }
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = [
+            {
+                'package_name': 'keep-package',
+                'owner_name': 'testuser',
+                'blocked': False,
+                'extra_arches': None
+            },
+            {
+                'package_name': 'remove-package',  # Should be removed
+                'owner_name': 'testuser',
+                'blocked': False,
+                'extra_arches': None
+            }
+        ]
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        remove_package_mock = Mock()
+        remove_package_mock.return_value = None
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+        self.queue_client_response('packageListRemove', remove_package_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        remove_package_mock.assert_called_once_with('existing-tag', 'remove-package', force=True)
+
+    def test_no_package_removal_without_exact_packages(self):
+        """Test that packages aren't removed when exact_packages=False."""
+
+        tag = create_test_tag('existing-tag', packages=[{'name': 'keep-package', 'owner': 'testuser'}])
+        tag.exact_packages = False  # Default behavior
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        # Mock the getTag call to return existing tag
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = {
+            'name': 'existing-tag',
+            'locked': False,
+            'perm': None,
+            'arches': '',
+            'maven_support': False,
+            'maven_include_all': False,
+            'extra': {}
+        }
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = [
+            {
+                'package_name': 'keep-package',
+                'owner_name': 'testuser',
+                'blocked': False,
+                'extra_arches': None
+            },
+            {
+                'package_name': 'extra-package',  # Should NOT be removed
+                'owner_name': 'testuser',
+                'blocked': False,
+                'extra_arches': None
+            }
+        ]
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        # No packageListRemove should have been queued
+        # We verify this implicitly - if there was a call, it would fail because we didn't queue a mock for it
+
+    def test_mixed_package_operations(self):
+        """Test applying multiple package operations in one step."""
+
+        tag = create_test_tag('existing-tag', packages=[
+            {'name': 'keep-package', 'owner': 'testuser'},  # Keep as-is
+            {'name': 'add-package', 'owner': 'testuser'},   # Add new
+            {'name': 'update-owner-package', 'owner': 'newowner'},  # Update owner
+            {'name': 'block-package', 'owner': 'testuser', 'blocked': True},  # Block
+        ])
+        tag.exact_packages = True
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        # Mock the getTag call to return existing tag
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = {
+            'name': 'existing-tag',
+            'locked': False,
+            'perm': None,
+            'arches': '',
+            'maven_support': False,
+            'maven_include_all': False,
+            'extra': {}
+        }
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = [
+            {
+                'package_name': 'keep-package',
+                'owner_name': 'testuser',
+                'blocked': False,
+                'extra_arches': None
+            },
+            {
+                'package_name': 'update-owner-package',
+                'owner_name': 'oldowner',
+                'blocked': False,
+                'extra_arches': None
+            },
+            {
+                'package_name': 'block-package',
+                'owner_name': 'testuser',
+                'blocked': False,  # Will be blocked
+                'extra_arches': None
+            },
+            {
+                'package_name': 'remove-package',
+                'owner_name': 'testuser',
+                'blocked': False,
+                'extra_arches': None
+            }
+        ]
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        add_package_mock = Mock()
+        add_package_mock.return_value = None
+
+        set_owner_mock = Mock()
+        set_owner_mock.return_value = None
+
+        block_package_mock = Mock()
+        block_package_mock.return_value = None
+
+        remove_package_mock = Mock()
+        remove_package_mock.return_value = None
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+        self.queue_client_response('packageListAdd', add_package_mock)
+        self.queue_client_response('packageListBlock', block_package_mock)
+        self.queue_client_response('packageListSetOwner', set_owner_mock)
+        self.queue_client_response('packageListRemove', remove_package_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        # Verify all operations were called
+        add_package_mock.assert_called_once_with(
+            'existing-tag',
+            'add-package',
+            owner='testuser',
+            block=False,
+            extra_arches=None
+        )
+        block_package_mock.assert_called_once_with('existing-tag', 'block-package', force=True)
+        set_owner_mock.assert_called_once_with('existing-tag', 'update-owner-package', 'newowner', force=True)
+        remove_package_mock.assert_called_once_with('existing-tag', 'remove-package', force=True)
+
+    def test_create_tag_with_packages(self):
+        """Test creating a new tag with packages from the start."""
+
+        tag = create_test_tag('new-tag', arches=['x86_64'], packages=[
+            {'name': 'package1', 'owner': 'testuser'},
+            {'name': 'package2', 'owner': 'testuser', 'blocked': True}
+        ])
+        solver = create_solver_with_objects([tag])
+        mock_session = create_test_koji_session()
+
+        get_tag_mock = Mock()
+        get_tag_mock.return_value = None  # Tag doesn't exist
+
+        get_tag_post_mock = Mock()
+        get_tag_post_mock.return_value = None
+
+        list_packages_mock = Mock()
+        list_packages_mock.return_value = []
+
+        get_groups_mock = Mock()
+        get_groups_mock.return_value = []
+
+        get_inheritance_mock = Mock()
+        get_inheritance_mock.return_value = []
+
+        get_external_repos_mock = Mock()
+        get_external_repos_mock.return_value = []
+
+        create_mock = Mock()
+        create_mock.return_value = None
+
+        set_extras_mock = Mock()
+        set_extras_mock.return_value = None
+
+        add_package1_mock = Mock()
+        add_package1_mock.return_value = None
+
+        add_package2_mock = Mock()
+        add_package2_mock.return_value = None
+
+        self.queue_client_response('getTag', get_tag_mock)
+        self.queue_client_response('listPackages', list_packages_mock)
+        self.queue_client_response('getTagGroups', get_groups_mock)
+        self.queue_client_response('getInheritanceData', get_inheritance_mock)
+        self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
+        self.queue_client_response('createTag', create_mock)
+        self.queue_client_response('editTag2', set_extras_mock)
+        self.queue_client_response('packageListAdd', add_package1_mock)
+        self.queue_client_response('packageListAdd', add_package2_mock)
+        self.queue_client_response('getTag', get_tag_post_mock)
+
+        processor = Processor(
+            koji_session=mock_session,
+            dataseries=solver,
+            resolver=create_empty_resolver(),
+            chunk_size=10
+        )
+
+        result = processor.step()
+        self.assertTrue(result)
+        self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
+
+        get_tag_mock.assert_called_once_with('new-tag', strict=False)
+        create_mock.assert_called_once()
+        # Verify both packages were added during creation
+        add_package1_mock.assert_called_once_with(
+            'new-tag',
+            'package1',
+            owner='testuser',
+            block=False,
+            extra_arches=None
+        )
+        add_package2_mock.assert_called_once_with(
+            'new-tag',
+            'package2',
+            owner='testuser',
+            block=True,
+            extra_arches=None
+        )
 
 
 # The end.

--- a/tests/test_processor_models/test_tag.py
+++ b/tests/test_processor_models/test_tag.py
@@ -1447,7 +1447,8 @@ class TestProcessorTagPackages(MulticallMocking, TestCase):
             'my-package',
             owner='testuser',
             block=False,
-            extra_arches=None
+            extra_arches=None,
+            force=True
         )
 
     def test_add_package_with_extra_arches(self):
@@ -1507,7 +1508,8 @@ class TestProcessorTagPackages(MulticallMocking, TestCase):
             'my-package',
             owner='testuser',
             block=False,
-            extra_arches='i686 ppc64le'
+            extra_arches='i686 ppc64le',
+            force=True
         )
 
     def test_block_package(self):
@@ -1984,7 +1986,8 @@ class TestProcessorTagPackages(MulticallMocking, TestCase):
             'add-package',
             owner='testuser',
             block=False,
-            extra_arches=None
+            extra_arches=None,
+            force=True
         )
         block_package_mock.assert_called_once_with('existing-tag', 'block-package', force=True)
         set_owner_mock.assert_called_once_with('existing-tag', 'update-owner-package', 'newowner', force=True)
@@ -2060,14 +2063,16 @@ class TestProcessorTagPackages(MulticallMocking, TestCase):
             'package1',
             owner='testuser',
             block=False,
-            extra_arches=None
+            extra_arches=None,
+            force=True
         )
         add_package2_mock.assert_called_once_with(
             'new-tag',
             'package2',
             owner='testuser',
             block=True,
-            extra_arches=None
+            extra_arches=None,
+            force=True
         )
 
 


### PR DESCRIPTION
## Overview
This PR adds support for managing package lists on tags, including package blocking, ownership, and architecture specifications. Includes comprehensive test coverage and bug fixes discovered during testing.

## Changes

### Core Features (9 commits, +1355/-53 lines)

#### Tag Model Package Support
- Added `packages` field to Tag model with PackageEntry submodel
- Support for package blocking, owner assignment, and extra-arches
- Simplified format validation (strings, dicts, or mixed)
- Package owner dependency resolution
- Change classes for all package operations (add, block, unblock, set owner/arches, remove)

#### Bug Fixes Found by Unit Tests
- Fixed `convert_packages_from_simplified()` validator logic errors
- Fixed `TagPackageListSetArches.impl_apply()` incorrect field access  
- Fixed `_compare_packages()` string-to-object comparison bug

#### Test Coverage
- **28 processor-level tests** (`tests/test_processor_models/test_tag.py`): Integration tests for package operations
- **28 model-level tests** (`tests/test_models/test_tag.py`): Field validation and conversion tests
- Reorganized model tests into 6 focused test classes for better maintainability

#### Other Improvements
- Enhanced YAML loader to save anchors across documents in the same file
- Added demo data with package list examples
- Force flag fixes for package operations

## Test Results
✅ All 56 new tests pass  
✅ All existing tests continue to pass

## Files Changed
- `koji_habitude/models/tag.py` (+186 lines): Package field and change classes
- `koji_habitude/loader.py` (+16 lines): Cross-document anchor support
- `tests/test_processor_models/test_tag.py` (+779 lines): Processor integration tests
- `tests/test_models/test_tag.py` (+356 lines): Model validation tests
- `tests/data/demo/*.yml` (+71 lines): Demo data with packages