### PR TITLE
Add skip-phantoms functionality to sync CLI

### DIFF
--- a/koji_habitude/cli/diff.py
+++ b/koji_habitude/cli/diff.py
@@ -13,7 +13,7 @@ import click
 
 from . import main
 from ..workflow import DiffWorkflow
-from .util import catchall, display_missing, display_summary
+from .util import catchall, display_resolver_report, display_summary
 
 
 @main.command()
@@ -43,9 +43,9 @@ def diff(data, templates=None, profile='koji', show_unchanged=False):
     workflow.run()
 
     display_summary(workflow.summary, show_unchanged)
-    display_missing(workflow.missing_report)
+    display_resolver_report(workflow.resolver_report)
 
-    return 1 if workflow.missing_report.missing else 0
+    return 1 if workflow.resolver_report.phantoms else 0
 
 
 # The end.

--- a/koji_habitude/cli/sync.py
+++ b/koji_habitude/cli/sync.py
@@ -37,8 +37,11 @@ class SyncWorkflow(_SyncWorkflow):
 @click.option(
     '--show-unchanged', 'show_unchanged', is_flag=True, default=False,
     help="Show objects that don't need any changes")
+@click.option(
+    '--skip-phantoms', 'skip_phantoms', is_flag=True, default=False,
+    help="Skip objects that are phantoms")
 @catchall
-def sync(data, templates=None, profile='koji', show_unchanged=False):
+def sync(data, templates=None, profile='koji', show_unchanged=False, skip_phantoms=False):
     """
     Synchronize local koji data expectations with hub instance.
 
@@ -49,7 +52,11 @@ def sync(data, templates=None, profile='koji', show_unchanged=False):
     definitions.
     """
 
-    workflow = SyncWorkflow(data, templates, profile)
+    workflow = SyncWorkflow(
+        data, templates,
+        profile=profile,
+        skip_phantoms=skip_phantoms)
+
     try:
         workflow.run()
     except WorkflowPhantomsError as e:

--- a/koji_habitude/cli/sync.py
+++ b/koji_habitude/cli/sync.py
@@ -13,20 +13,17 @@ import click
 
 from . import main
 from ..workflow import SyncWorkflow as _SyncWorkflow
-from ..workflow import WorkflowMissingObjectsError
-from .diff import catchall, display_missing, display_summary
+from ..workflow import WorkflowPhantomsError
+from .util import catchall, display_resolver_report, display_summary
 
 
 class SyncWorkflow(_SyncWorkflow):
 
-    def processor_step_callback(self, step, handled):
-        click.echo(f"Step #{step} processed chunk of {handled} objects")
-        report = self.resolver.report()
-        if report.missing:
-            for key in report.missing:
-                click.echo(f"Dependency missing: {key[0]} {key[1]}")
-            msg = "Missing dependencies found in the system"
-            raise click.ClickException(msg)
+    def workflow_state_change(self, from_state, to_state) -> bool:
+        return False
+
+    def processor_step_callback(self, step, handled) -> None:
+        pass
 
 
 @main.command()
@@ -52,17 +49,16 @@ def sync(data, templates=None, profile='koji', show_unchanged=False):
     definitions.
     """
 
+    workflow = SyncWorkflow(data, templates, profile)
     try:
-        workflow = SyncWorkflow(data, templates, profile)
         workflow.run()
-    except WorkflowMissingObjectsError as e:
-        display_missing(e.report)
+    except WorkflowPhantomsError as e:
+        display_resolver_report(e.report)
         return 1
-
-    display_summary(workflow.summary, show_unchanged)
-    display_missing(workflow.missing_report)
-
-    return 0
+    else:
+        display_summary(workflow.summary, show_unchanged)
+        display_resolver_report(workflow.resolver_report)
+        return 0
 
 
 # The end.

--- a/koji_habitude/cli/util.py
+++ b/koji_habitude/cli/util.py
@@ -124,20 +124,21 @@ def display_summary(summary, show_unchanged):
     click.echo()
 
 
-def display_missing(report):
+def display_resolver_report(report):
     if report:
-        total_dependencies = len(report.found) + len(report.missing)
-        click.echo(f"Resolver identified {total_dependencies} dependencies not defined in the data set")
-        click.echo(f"({len(report.found)} were found in the system, {len(report.missing)} remain missing)")
+        total_dependencies = len(report.discovered) + len(report.phantoms)
+        click.echo(f"Resolver identified {total_dependencies} dependency references not defined in the data set")
+        click.echo(f"({len(report.discovered)} were discovered in the system,"
+                   f" {len(report.phantoms)} phantoms remain)")
 
-    if report.found:
-        click.echo("Found objects:")
-        for key in report.found:
+    if report.discovered:
+        click.echo("Discovered references:")
+        for key in report.discovered:
             click.echo(f"  {key[0]} {key[1]}")
 
-    if report.missing:
-        click.echo("Missing objects:")
-        for key in report.missing:
+    if report.phantoms:
+        click.echo("Phantom references:")
+        for key in report.phantoms:
             click.echo(f"  {key[0]} {key[1]}")
 
     click.echo()

--- a/koji_habitude/cli/util.py
+++ b/koji_habitude/cli/util.py
@@ -16,6 +16,14 @@ from pydantic import ValidationError
 from koji import GSSAPIAuthError, GenericError
 
 
+__all__ = (
+    'catchall',
+    'display_summary',
+    'display_resolver_report',
+    'resplit',
+)
+
+
 def resplit(strs: List[str], sep=',') -> List[str]:
     """
     Takes a list of strings which may be comma-separated to indicate multiple

--- a/koji_habitude/cli/util.py
+++ b/koji_habitude/cli/util.py
@@ -9,7 +9,7 @@ AI-Assistant: Claude 3.5 Sonnet via Cursor
 """
 
 
-import click
+from click import echo
 from typing import List
 from functools import wraps
 from pydantic import ValidationError
@@ -38,23 +38,23 @@ def catchall(func):
             return func(*args, **kwargs)
 
         except ValidationError as e:
-            click.echo(f"[ValidationError] {e}", err=True)
+            echo(f"[ValidationError] {e}", err=True)
             return 1
 
         except GSSAPIAuthError as e:
-            click.echo(f"[GSSAPIAuthError] {e}", err=True)
+            echo(f"[GSSAPIAuthError] {e}", err=True)
             return 1
 
         except GenericError as e:
-            click.echo(f"[GenericError] {e}", err=True)
+            echo(f"[GenericError] {e}", err=True)
             return 1
 
         except KeyboardInterrupt:
-            click.echo("[Keyboard interrupt]", err=True)
+            echo("[Keyboard interrupt]", err=True)
             return 130
 
         except Exception as e:
-            click.echo(f"[Error] {e}", err=True)
+            echo(f"[Error] {e}", err=True)
             raise
 
     return wrapper
@@ -80,21 +80,21 @@ def display_summary(summary, show_unchanged):
 
     # Display objects with changes
     if by_type:
-        click.echo("Objects with changes:")
-        click.echo()
+        echo("Objects with changes:")
+        echo()
 
         for typename in sorted(by_type.keys()):
-            click.echo(f"{typename}:")
+            echo(f"{typename}:")
             for name, change_report in sorted(by_type[typename]):
-                click.echo(f"  {name}:")
+                echo(f"  {name}:")
                 for change in change_report.changes:
-                    click.echo(f"    {change.explain()}")
-            click.echo()
+                    echo(f"    {change.explain()}")
+            echo()
 
     # Display unchanged objects if requested
     if show_unchanged and unchanged_objects:
-        click.echo("Objects with no changes needed:")
-        click.echo()
+        echo("Objects with no changes needed:")
+        echo()
 
         by_type_unchanged = {}
         for typename, name in unchanged_objects:
@@ -103,10 +103,10 @@ def display_summary(summary, show_unchanged):
             by_type_unchanged[typename].append(name)
 
         for typename in sorted(by_type_unchanged.keys()):
-            click.echo(f"{typename}:")
+            echo(f"{typename}:")
             for name in sorted(by_type_unchanged[typename]):
-                click.echo(f"  {name}")
-            click.echo()
+                echo(f"  {name}")
+            echo()
 
     # Summary
     total_changes = summary.total_changes
@@ -114,34 +114,34 @@ def display_summary(summary, show_unchanged):
     unchanged_count = len(unchanged_objects)
 
     if total_changes > 0:
-        click.echo(f"Summary: {total_changes} changes across {total_objects - unchanged_count} objects")
+        echo(f"Summary: {total_changes} changes across {total_objects - unchanged_count} objects")
     else:
-        click.echo("Summary: No changes needed")
+        echo("Summary: No changes needed")
 
     if show_unchanged and unchanged_count > 0:
-        click.echo(f"({unchanged_count} objects unchanged)")
+        echo(f"({unchanged_count} objects unchanged)")
 
-    click.echo()
+    echo()
 
 
 def display_resolver_report(report):
     if report:
         total_dependencies = len(report.discovered) + len(report.phantoms)
-        click.echo(f"Resolver identified {total_dependencies} dependency references not defined in the data set")
-        click.echo(f"({len(report.discovered)} were discovered in the system,"
+        echo(f"Resolver identified {total_dependencies} dependency references not defined in the data set")
+        echo(f"({len(report.discovered)} were discovered in the system,"
                    f" {len(report.phantoms)} phantoms remain)")
 
     if report.discovered:
-        click.echo("Discovered references:")
+        echo("Discovered references:")
         for key in report.discovered:
-            click.echo(f"  {key[0]} {key[1]}")
+            echo(f"  {key[0]} {key[1]}")
 
     if report.phantoms:
-        click.echo("Phantom references:")
+        echo("Phantom references:")
         for key in report.phantoms:
-            click.echo(f"  {key[0]} {key[1]}")
+            echo(f"  {key[0]} {key[1]}")
 
-    click.echo()
+    echo()
 
 
 # The end.

--- a/koji_habitude/models/__init__.py
+++ b/koji_habitude/models/__init__.py
@@ -15,7 +15,7 @@ from typing import Tuple, Type
 from types import MappingProxyType
 
 
-from .base import Base, BaseObject, BaseKey
+from .base import Base, BaseObject, BaseKey, BaseStatus
 from .change import ChangeReport, Change
 from .channel import Channel
 from .external_repo import ExternalRepo
@@ -34,8 +34,10 @@ __all__ = (
     'Base',
     'BaseObject',
     'BaseKey',
-    'ChangeReport',
+    'BaseStatus',
+
     'Change',
+    'ChangeReport',
 
     'Channel',
     'ExternalRepo',

--- a/koji_habitude/models/base.py
+++ b/koji_habitude/models/base.py
@@ -11,14 +11,15 @@ AI-Assistant: Claude 3.5 Sonnet via Cursor
 # Vibe-Coding State: AI Generated with Human Rework
 
 
-from pydantic import BaseModel, Field, ConfigDict
-from koji import ClientSession, VirtualCall
+from enum import StrEnum
 from typing import (
     TYPE_CHECKING,
     Any, ClassVar, Dict, List, Optional, Protocol,
     Sequence, Tuple, Type, TypeAlias,
 )
 
+from pydantic import BaseModel, Field, ConfigDict
+from koji import ClientSession, VirtualCall
 
 if TYPE_CHECKING:
     from .change import ChangeReport
@@ -28,6 +29,7 @@ if TYPE_CHECKING:
 __all__ = (
     'Base',
     'BaseKey',
+    'BaseStatus',
     'BaseObject',
     'SubModel',
 )
@@ -37,6 +39,32 @@ BaseKey: TypeAlias = Tuple[str, str]
 """
 A tuple of (typename, name), used as the key for objects across this package
 """
+
+
+class BaseStatus(StrEnum):
+    """
+    Indicates the status of an object
+    """
+
+    PRESENT = "present"
+    """
+    Defined in a Namespace, and known to exist on the Koji instance
+    """
+
+    PENDING = "pending"
+    """
+    Defined in a Namespace, but not known to exist on the Koji instance
+    """
+
+    DISCOVERED = "discovered"
+    """
+    Dependency which is not defined in a Namespace, but is known to exist on the Koji instance
+    """
+
+    PHANTOM = "phantom"
+    """
+    Dependency which is not defined in a Namespace, and not known to exist on the Koji instance
+    """
 
 
 class Base(Protocol):
@@ -71,14 +99,30 @@ class Base(Protocol):
     def dependency_keys(self) -> Sequence[BaseKey]:
         ...
 
+    @property
+    def status(self) -> BaseStatus:
+        """
+        Indicates the status of this object
+        """
+        ...
+
     def exists(self) -> Any:
+        """
+        Indicates whether this object is known to exist on the Koji instance
+        """
         ...
 
     def query_exists(self, session: ClientSession) -> VirtualCall:
+        """
+        Resolve the existence of this object on the Koji instance
+        """
         ...
 
     @classmethod
     def check_exists(cls, session: ClientSession, key: BaseKey) -> Any:
+        """
+        Check the existence of a key of the given type and name on the Koji instance
+        """
         ...
 
     @classmethod
@@ -137,11 +181,24 @@ class BaseObject(BaseModel, Base, metaclass=MetaModelProtocol):  # type: ignore
         self._exists = None
 
 
+    @property
+    def status(self) -> BaseStatus:
+        # Reference objects will override this to return DISCOVERED or PHANTOM. But since
+        # objects of our types will always exist due to being defied in the Namespace,
+        # we don't worry about the Reference cases here.
+        return BaseStatus.PRESENT if self.exists() is not None else BaseStatus.PENDING
+
+
     def exists(self) -> Any:
+        # Check the value of the VirtualCall returned by the last `query_exists`
+        # call.
         return self._exists.result if self._exists is not None else None
 
 
     def query_exists(self, session: ClientSession) -> VirtualCall:
+        # the default implementation defers to `check_exists` so that subclasses
+        # only need to implement that classmethod to provide the existence
+        # check.
         res = self.check_exists(session, self.key())
         if isinstance(res, VirtualCall):
             self._exists = res
@@ -169,7 +226,9 @@ class BaseObject(BaseModel, Base, metaclass=MetaModelProtocol):  # type: ignore
 
     def to_dict(self) -> Dict[str, Any]:
         """
-        Return a dictionary representation of this object.
+        Return a dictionary representation of this object. This is distinct from
+        the original data that was used to create the object, and may include
+        fields with default values and validated forms.
         """
         return self.model_dump(by_alias=True)
 
@@ -236,7 +295,8 @@ class BaseObject(BaseModel, Base, metaclass=MetaModelProtocol):  # type: ignore
 
     def dependency_keys(self) -> Sequence[BaseKey]:
         """
-        Return the keys of the dependencies of this object as a sequence of (typename, name) tuples
+        Return the keys of the dependencies of this object as a sequence of
+        (typename, name) tuples
         """
         return ()
 

--- a/koji_habitude/models/channel.py
+++ b/koji_habitude/models/channel.py
@@ -17,7 +17,7 @@ from typing import ClassVar, List, Optional, Any, TYPE_CHECKING
 from koji import ClientSession, MultiCallSession, VirtualCall
 from pydantic import Field
 
-from .base import BaseObject, BaseKey
+from .base import BaseObject, BaseKey, BaseStatus
 from .change import ChangeReport, Change
 
 if TYPE_CHECKING:
@@ -56,6 +56,12 @@ class ChannelSetDescription(Change):
 class ChannelAddHost(Change):
     name: str
     host: str
+
+    _skippable: ClassVar[bool] = True
+
+    def skip_check_impl(self, resolver: 'Resolver') -> bool:
+        host = resolver.resolve(('host', self.host))
+        return host.status == BaseStatus.PHANTOM
 
     def impl_apply(self, session: MultiCallSession):
         return session.addHostToChannel(self.host, self.name)

--- a/koji_habitude/models/channel.py
+++ b/koji_habitude/models/channel.py
@@ -17,7 +17,7 @@ from typing import ClassVar, List, Optional, Any, TYPE_CHECKING
 from koji import ClientSession, MultiCallSession, VirtualCall
 from pydantic import Field
 
-from .base import BaseObject, BaseKey, BaseStatus
+from .base import BaseObject, BaseKey
 from .change import ChangeReport, Change
 
 if TYPE_CHECKING:
@@ -61,7 +61,7 @@ class ChannelAddHost(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         host = resolver.resolve(('host', self.host))
-        return host.status == BaseStatus.PHANTOM
+        return host.is_phantom()
 
     def impl_apply(self, session: MultiCallSession):
         return session.addHostToChannel(self.host, self.name)

--- a/koji_habitude/models/group.py
+++ b/koji_habitude/models/group.py
@@ -17,7 +17,7 @@ from typing import ClassVar, List, Tuple, Any, TYPE_CHECKING
 from koji import ClientSession, MultiCallSession, VirtualCall
 from pydantic import Field
 
-from .base import BaseObject, BaseKey
+from .base import BaseObject, BaseKey, BaseStatus
 from .change import Change, ChangeReport
 
 if TYPE_CHECKING:
@@ -62,6 +62,12 @@ class GroupAddMember(Change):
     name: str
     member: str
 
+    _skippable: ClassVar[bool] = True
+
+    def skip_check_impl(self, resolver: 'Resolver') -> bool:
+        member = resolver.resolve(('user', self.member))
+        return member.status == BaseStatus.PHANTOM
+
     def impl_apply(self, session: MultiCallSession):
         return session.addGroupMember(self.name, self.member)
 
@@ -85,6 +91,12 @@ class GroupRemoveMember(Change):
 class GroupAddPermission(Change):
     name: str
     permission: str
+
+    _skippable: ClassVar[bool] = True
+
+    def skip_check_impl(self, resolver: 'Resolver') -> bool:
+        permission = resolver.resolve(('permission', self.permission))
+        return permission.status == BaseStatus.PHANTOM
 
     def impl_apply(self, session: MultiCallSession):
         return session.grantPermission(self.name, self.permission, create=True)

--- a/koji_habitude/models/group.py
+++ b/koji_habitude/models/group.py
@@ -17,7 +17,7 @@ from typing import ClassVar, List, Tuple, Any, TYPE_CHECKING
 from koji import ClientSession, MultiCallSession, VirtualCall
 from pydantic import Field
 
-from .base import BaseObject, BaseKey, BaseStatus
+from .base import BaseObject, BaseKey
 from .change import Change, ChangeReport
 
 if TYPE_CHECKING:
@@ -66,7 +66,7 @@ class GroupAddMember(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         member = resolver.resolve(('user', self.member))
-        return member.status == BaseStatus.PHANTOM
+        return member.is_phantom()
 
     def impl_apply(self, session: MultiCallSession):
         return session.addGroupMember(self.name, self.member)
@@ -96,7 +96,7 @@ class GroupAddPermission(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         permission = resolver.resolve(('permission', self.permission))
-        return permission.status == BaseStatus.PHANTOM
+        return permission.is_phantom()
 
     def impl_apply(self, session: MultiCallSession):
         return session.grantPermission(self.name, self.permission, create=True)

--- a/koji_habitude/models/host.py
+++ b/koji_habitude/models/host.py
@@ -17,7 +17,7 @@ from typing import ClassVar, List, Sequence, Optional, Any, TYPE_CHECKING
 from koji import MultiCallSession, VirtualCall, ClientSession
 from pydantic import Field
 
-from .base import BaseObject, BaseKey, BaseStatus
+from .base import BaseObject, BaseKey
 from .change import ChangeReport, Change
 
 if TYPE_CHECKING:
@@ -98,7 +98,7 @@ class HostAddChannel(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         channel = resolver.resolve(('channel', self.channel))
-        return channel.status == BaseStatus.PHANTOM
+        return channel.is_phantom()
 
     def impl_apply(self, session: MultiCallSession):
         return session.addHostToChannel(self.name, self.channel)

--- a/koji_habitude/models/host.py
+++ b/koji_habitude/models/host.py
@@ -17,7 +17,7 @@ from typing import ClassVar, List, Sequence, Optional, Any, TYPE_CHECKING
 from koji import MultiCallSession, VirtualCall, ClientSession
 from pydantic import Field
 
-from .base import BaseObject, BaseKey
+from .base import BaseObject, BaseKey, BaseStatus
 from .change import ChangeReport, Change
 
 if TYPE_CHECKING:
@@ -93,6 +93,12 @@ class HostSetDescription(Change):
 class HostAddChannel(Change):
     name: str
     channel: str
+
+    _skippable: ClassVar[bool] = True
+
+    def skip_check_impl(self, resolver: 'Resolver') -> bool:
+        channel = resolver.resolve(('channel', self.channel))
+        return channel.status == BaseStatus.PHANTOM
 
     def impl_apply(self, session: MultiCallSession):
         return session.addHostToChannel(self.name, self.channel)

--- a/koji_habitude/models/tag.py
+++ b/koji_habitude/models/tag.py
@@ -306,20 +306,14 @@ class TagAddInheritance(Change):
         tag = resolver.resolve(self.parent.key())
         logger.debug(f"Resolved parent tag '{self.parent.name}' to {tag}")
 
-        try:
-            tinfo = tag.exists()
-        except MultiCallNotReady:
+        tinfo = tag.exists()
+        if tinfo is None:
             logger.debug(f"MultiCallNotReady, breaking out of multicall")
             return True
 
-        logger.debug(f"  exists: {tinfo}")
-
-        if tinfo:
-            logger.debug(f"Parent tag '{self.parent.name}' exists, ID: {tinfo['id']}")
-            self.parent._parent_tag_id = tinfo['id']
-            return False
-        else:
-            raise ValueError(f"Parent tag '{self.parent.name}' does not exist")
+        logger.debug(f"Parent tag '{self.parent.name}' exists, ID: {tinfo['id']}")
+        self.parent._parent_tag_id = tinfo['id']
+        return False
 
 
 @dataclass

--- a/koji_habitude/models/tag.py
+++ b/koji_habitude/models/tag.py
@@ -308,6 +308,7 @@ class TagAddInheritance(Change):
 
         tinfo = tag.exists()
         if tinfo is None:
+            assert not tag.is_phantom()
             logger.debug(f"MultiCallNotReady, breaking out of multicall")
             return True
 

--- a/koji_habitude/models/tag.py
+++ b/koji_habitude/models/tag.py
@@ -17,7 +17,7 @@ from pydantic import Field, field_validator, model_validator
 
 from koji import ClientSession, MultiCallNotReady, MultiCallSession, VirtualCall
 
-from .base import BaseKey, BaseObject, SubModel, BaseStatus
+from .base import BaseKey, BaseObject, SubModel
 from .change import Change, ChangeReport
 
 if TYPE_CHECKING:
@@ -101,7 +101,7 @@ class TagSetPermission(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         permission = resolver.resolve(('permission', self.permission))
-        return permission.status == BaseStatus.PHANTOM
+        return permission.is_phantom()
 
     def impl_apply(self, session: MultiCallSession):
         return session.editTag2(self.name, perm=self.permission)
@@ -265,7 +265,7 @@ class TagAddInheritance(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         parent = resolver.resolve(self.parent.key())
-        return parent.status == BaseStatus.PHANTOM
+        return parent.is_phantom()
 
     def impl_apply(self, session: MultiCallSession):
         data = [{
@@ -372,7 +372,7 @@ class TagAddExternalRepo(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         repo = resolver.resolve(('external-repo', self.repo.name))
-        return repo.status == BaseStatus.PHANTOM
+        return repo.is_phantom()
 
     def impl_apply(self, session: MultiCallSession):
         arches = ' '.join(self.repo.arches) if self.repo.arches else None

--- a/koji_habitude/models/target.py
+++ b/koji_habitude/models/target.py
@@ -14,7 +14,7 @@ from typing import Any, ClassVar, Optional, Sequence, TYPE_CHECKING
 from koji import ClientSession, MultiCallSession, VirtualCall
 from pydantic import Field
 
-from .base import BaseKey, BaseObject, BaseStatus
+from .base import BaseKey, BaseObject
 from .change import Change, ChangeReport
 
 if TYPE_CHECKING:
@@ -31,12 +31,12 @@ class TargetCreate(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         build_tag = resolver.resolve(('tag', self.build_tag))
-        if build_tag.status == BaseStatus.PHANTOM:
+        if build_tag.is_phantom():
             return True
 
         dest_tag = self.dest_tag or self.name
         dest_tag = resolver.resolve(('tag', dest_tag))
-        if dest_tag.status == BaseStatus.PHANTOM:
+        if dest_tag.is_phantom():
             return True
 
         return False
@@ -59,12 +59,12 @@ class TargetEdit(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         build_tag = resolver.resolve(('tag', self.build_tag))
-        if build_tag.status == BaseStatus.PHANTOM:
+        if build_tag.is_phantom():
             return True
 
         dest_tag = self.dest_tag or self.name
         dest_tag = resolver.resolve(('tag', dest_tag))
-        if dest_tag.status == BaseStatus.PHANTOM:
+        if dest_tag.is_phantom():
             return True
 
         return False

--- a/koji_habitude/models/user.py
+++ b/koji_habitude/models/user.py
@@ -17,7 +17,7 @@ from typing import ClassVar, List, Optional, Any, TYPE_CHECKING
 from koji import MultiCallSession, VirtualCall, ClientSession
 from pydantic import Field
 
-from .base import BaseKey, BaseObject, BaseStatus
+from .base import BaseKey, BaseObject
 from .change import Change, ChangeReport
 
 if TYPE_CHECKING:
@@ -72,7 +72,7 @@ class UserGrantPermission(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         perm = resolver.resolve(('permission', self.permission))
-        return perm.status == BaseStatus.PHANTOM
+        return perm.is_phantom()
 
     def impl_apply(self, session: MultiCallSession):
         return session.grantPermission(self.name, self.permission, create=True)
@@ -102,7 +102,7 @@ class UserAddToGroup(Change):
 
     def skip_check_impl(self, resolver: 'Resolver') -> bool:
         group = resolver.resolve(('group', self.group))
-        return group.status == BaseStatus.PHANTOM
+        return group.is_phantom()
 
     def impl_apply(self, session: MultiCallSession):
         return session.addGroupMember(self.group, self.name, strict=False)

--- a/koji_habitude/models/user.py
+++ b/koji_habitude/models/user.py
@@ -8,6 +8,8 @@ License: GNU General Public License v3
 AI-Assistant: Claude 3.5 Sonnet via Cursor
 """
 
+# Vibe-Coding State: AI Assisted, Mostly Human
+
 
 from dataclasses import dataclass
 from typing import ClassVar, List, Optional, Any, TYPE_CHECKING
@@ -65,6 +67,12 @@ class UserDisable(Change):
 class UserGrantPermission(Change):
     name: str
     permission: str
+
+    _skippable: ClassVar[bool] = True
+
+    def skip_check_impl(self, resolver: 'Resolver') -> bool:
+        perm = resolver.resolve(('permission', self.permission))
+        return perm.missing() and not perm.exists()
 
     def impl_apply(self, session: MultiCallSession):
         return session.grantPermission(self.name, self.permission, create=True)

--- a/koji_habitude/namespace.py
+++ b/koji_habitude/namespace.py
@@ -169,7 +169,7 @@ class Namespace:
 
     def __init__(
             self,
-            coretypes: Dict[str, Type[Base]] | Sequence[Type[Base]] = CORE_MODELS,
+            coretypes: Union[Dict[str, Type[Base]], Sequence[Type[Base]]] = CORE_MODELS,
             enable_templates: bool = True,
             redefine: Redefine = Redefine.ERROR,
             logger: Optional[logging.Logger] = None):
@@ -184,7 +184,7 @@ class Namespace:
             coretypes = dict(coretypes)
         else:
             coretypes = {tp.typename: tp for tp in coretypes}
-        self.typemap: Dict[str | None, Type[Base]] = coretypes
+        self.typemap: Dict[Optional[str], Type[Base]] = coretypes
 
         if enable_templates:
             self.typemap["template"] = Template
@@ -230,7 +230,7 @@ class Namespace:
         return self._ns.values()
 
 
-    def get(self, key: BaseKey, default: Any = None) -> Base | None:
+    def get(self, key: BaseKey, default: Any = None) -> Optional[Base]:
         """
         Return the object in the namespace with the given key.
         """
@@ -259,15 +259,17 @@ class Namespace:
         merge_into(self._templates, other._templates, redefine, self.logger)
 
 
-    def get_type(self, typename: str, no_call: bool = False) -> Type[Base] | None:
+    def get_type(self, typename: str, or_call: bool = True) -> Optional[Type[Base]]:
         """
-        Return the type for the given typename. If no_call is True, will not
-        return a TemplateCall for missing type names.
+        Return the type for the given typename. If or_call is True (the
+        default), will return a TemplateCall for missing type names. If or_call
+        is False, or if the Namespace was not created with templates enabled,
+        then this will return None for missing type names.
         """
-        if no_call:
-            return self.typemap.get(typename)
-        else:
+        if or_call:
             return self.typemap.get(typename) or self.typemap.get(None)
+        else:
+            return self.typemap.get(typename)
 
 
     def to_object(self, objdict: Dict[str, Any]) -> Base:
@@ -487,7 +489,7 @@ class TemplateNamespace(Namespace):
 
     def __init__(
             self,
-            coretypes: Dict[str, Type[Base]] | Sequence[Type[Base]] = CORE_MODELS,
+            coretypes: Union[Dict[str, Type[Base]], Sequence[Type[Base]]] = CORE_MODELS,
             redefine: Redefine = Redefine.ERROR,
             logger: Optional[logging.Logger] = None):
 
@@ -512,7 +514,7 @@ class TemplateNamespace(Namespace):
         return filter(None, map(self.to_object, dataseq))
 
 
-    def to_object(self, data: Dict[str, Any]) -> Base | None:
+    def to_object(self, data: Dict[str, Any]) -> Optional[Base]:
         if data['type'] in self.ignored_types:
             return None
         return super().to_object(data)
@@ -535,7 +537,7 @@ class ExpanderNamespace(Namespace):
 
     def __init__(
         self,
-        coretypes: Dict[str, Type[Base]] | Sequence[Type[Base]] = CORE_MODELS,
+        coretypes: Union[Dict[str, Type[Base]], Sequence[Type[Base]]]= CORE_MODELS,
         redefine: Redefine = Redefine.ERROR,
         logger: Optional[logging.Logger] = None):
 

--- a/koji_habitude/namespace.py
+++ b/koji_habitude/namespace.py
@@ -26,6 +26,7 @@ from typing import (
     Set,
     Tuple,
     Type,
+    Union,
 )
 
 from .models import Base, BaseKey, BaseObject, CORE_MODELS

--- a/koji_habitude/resolver.py
+++ b/koji_habitude/resolver.py
@@ -31,7 +31,7 @@ from typing import (
     Type,
 )
 
-from koji import ClientSession, MultiCallSession, VirtualCall
+from koji import ClientSession, MultiCallSession, VirtualCall, MultiCallNotReady
 
 from .koji import multicall
 from .models import Base, BaseKey, BaseStatus, ChangeReport
@@ -90,8 +90,14 @@ class Reference(Base):
     def status(self) -> BaseStatus:
         return BaseStatus.DISCOVERED if self.exists() else BaseStatus.PHANTOM
 
+    def is_phantom(self) -> bool:
+        return self.exists() is None
+
     def exists(self) -> Any:
-        return self._exists.result if self._exists is not None else None
+        try:
+            return self._exists.result if self._exists is not None else None
+        except MultiCallNotReady:
+            return None
 
     def key(self) -> BaseKey:
         return self._key

--- a/koji_habitude/resolver.py
+++ b/koji_habitude/resolver.py
@@ -147,7 +147,7 @@ class ResolverReport:
     """
 
     discovered: Dict[BaseKey, Base]
-    phantom: Dict[BaseKey, Base]
+    phantoms: Dict[BaseKey, Base]
 
 
 class Resolver:
@@ -303,13 +303,13 @@ class Resolver:
         """
 
         discovered = {}
-        phantom = {}
+        phantoms = {}
         for key, obj in self._references.items():
             if obj.exists():
                 discovered[key] = obj
             else:
-                phantom[key] = obj
-        return ResolverReport(discovered=discovered, phantom=phantom)
+                phantoms[key] = obj
+        return ResolverReport(discovered=discovered, phantoms=phantoms)
 
 
 # The end.

--- a/koji_habitude/resolver.py
+++ b/koji_habitude/resolver.py
@@ -280,21 +280,18 @@ class Resolver:
         return self.resolve(key).query_exists(session)
 
 
-    def query_exists_references(self, session: ClientSession) -> int:
+    def query_exists_references(self, session: ClientSession) -> None:
         """
         creates a multicall for session, and queries for the existence of all
-        current reference objects. Returns a count of reference objects which were
-        not found to exist on the Koji instance (ie. the count of phantoms)
+        current reference objects.
         """
 
         if not self._references:
-            return 0
+            return
 
         with multicall(session) as mc:
             for key in self._references.keys():
                 self.query_exists_key(mc, key)
-
-        return len(self.phantom_keys())
 
 
     def report(self) -> ResolverReport:

--- a/koji_habitude/solver.py
+++ b/koji_habitude/solver.py
@@ -23,6 +23,11 @@ from .resolver import Report, Resolver
 
 
 class Node:
+    """
+    Represents a node in the dependency graph, wrapping a Base object of some
+    type. Used internally by the Solver to track dependency links.
+    """
+
     def __init__(self, obj: Base, splitable: bool = None):
         self.key: BaseKey = obj.key()
         self.obj: Base = obj
@@ -136,9 +141,9 @@ class Solver:
     def __iter__(self) -> Iterator[Base]:
         # create a list of nodes, sorted by priority
 
+        acted: bool = False
         work: List[Node] = sorted(self.remaining.values(),
                                   key=Node.get_priority)
-        acted: bool = False
 
         while work:
             for node in work:
@@ -157,8 +162,9 @@ class Solver:
                 else:
                     raise ValueError("Stuck in a loop")
 
-            work = sorted(self.remaining.values(), key=Node.get_priority)
             acted = False
+            work = sorted(self.remaining.values(),
+                          key=Node.get_priority)
 
         assert len(self.remaining) == 0
 

--- a/koji_habitude/solver.py
+++ b/koji_habitude/solver.py
@@ -16,10 +16,12 @@ AI-Assistant: Claude 3.5 Sonnet via Cursor
 # the AI never actually emitted code.
 
 
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple
 
 from .models import Base, BaseKey
-from .resolver import Report, Resolver
+
+if TYPE_CHECKING:
+    from .resolver import ResolverReport, Resolver
 
 
 class Node:
@@ -82,10 +84,10 @@ class Solver:
 
     def __init__(
             self,
-            resolver: Resolver,
+            resolver: 'Resolver',
             work: Optional[List[BaseKey]] = None):
 
-        self.resolver: Resolver = resolver
+        self.resolver: 'Resolver' = resolver
         self.work: Optional[List[BaseKey]] = work
         self.remaining: Optional[Dict[BaseKey, Node]] = None
 
@@ -117,7 +119,7 @@ class Solver:
                 node.add_dependency(depnode)
 
 
-    def report(self) -> Report:
+    def report(self) -> 'ResolverReport':
         if self.remaining is None:
             raise ValueError("Solver not prepared")
         return self.resolver.report()

--- a/koji_habitude/templates.py
+++ b/koji_habitude/templates.py
@@ -202,6 +202,11 @@ class Template(BaseObject):
 
 
     def get_missing(self):
+        """
+        Return the set of variable names which are referenced in the Jinja2
+        template, but which are not defined in the defaults
+        """
+
         return self._undeclared.difference(self.defaults)
 
 

--- a/koji_habitude/workflow.py
+++ b/koji_habitude/workflow.py
@@ -204,7 +204,7 @@ class Workflow:
         are any phantoms.
         """
 
-        phantoms = self.resolver_report.phantoms_keys()
+        phantoms = self.resolver_report.phantoms()
         if len(phantoms) > 0 and not self.skip_phantoms:
             self.state = WorkflowState.FAILED
             raise WorkflowPhantomsError(

--- a/koji_habitude/workflow.py
+++ b/koji_habitude/workflow.py
@@ -204,7 +204,7 @@ class Workflow:
         are any phantoms.
         """
 
-        phantoms = self.resolver_report.phantoms()
+        phantoms = self.resolver_report.phantoms
         if len(phantoms) > 0 and not self.skip_phantoms:
             self.state = WorkflowState.FAILED
             raise WorkflowPhantomsError(

--- a/koji_habitude/workflow.py
+++ b/koji_habitude/workflow.py
@@ -30,7 +30,7 @@ from .loader import MultiLoader, YAMLLoader
 from .models import Base
 from .namespace import Namespace, TemplateNamespace
 from .processor import DiffOnlyProcessor, Processor, ProcessorSummary
-from .resolver import Resolver, Report
+from .resolver import Resolver, ResolverReport
 from .solver import Solver
 
 
@@ -56,6 +56,8 @@ class WorkflowState(Enum):
     SOLVED = "solved"
     CONNECTING = "connecting"
     CONNECTED = "connected"
+    RESOLVING = "resolving"
+    RESOLVED = "resolved"
     PROCESSING = "processing"
     PROCESSED = "processed"
     COMPLETED = "completed"
@@ -69,11 +71,11 @@ class WorkflowStateError(Exception):
     pass
 
 
-class WorkflowMissingObjectsError(Exception):
+class WorkflowPhantomsError(Exception):
     """
-    Exception raised when the workflow has missing objects.
+    Exception raised when the workflow has phantoms.
     """
-    def __init__(self, message: str, report: Report):
+    def __init__(self, message: str, report: ResolverReport):
         super().__init__(message)
         self.report = report
 
@@ -85,6 +87,7 @@ class Workflow:
     template_paths: List[str | Path] = None
     profile: str = 'koji'
     chunk_size: int = 100
+    skip_phantoms: bool = False
 
     cls_multiloader: Type[MultiLoader] = MultiLoader
     cls_yamlloader: Type[YAMLLoader] = YAMLLoader
@@ -102,7 +105,7 @@ class Workflow:
 
     dataseries: List[Base] = field(init=False, default=None)
     summary: ProcessorSummary = field(init=False, default=None)
-    missing_report: Report = field(init=False, default=None)
+    resolver_report: ResolverReport = field(init=False, default=None)
 
     state: WorkflowState = field(init=False, default=WorkflowState.READY)
     _iter_workflow: Iterator[bool] = field(init=False, default=None)
@@ -183,42 +186,42 @@ class Workflow:
                                 WorkflowState.CONNECTED)
 
 
-    def review_missing_report(self):
+    def run_resolving(self):
+        yield self.state_change(WorkflowState.CONNECTED,
+                                WorkflowState.RESOLVING)
+
+        self.resolver.query_exists_references(self.session)
+        self.resolver_report = self.resolver.report()
+        self.review_resolver_report()
+
+        yield self.state_change(WorkflowState.RESOLVING,
+                                WorkflowState.RESOLVED)
+
+
+    def review_resolver_report(self):
         """
-        Review the missing report and raise an exception if there
-        are any missing objects.
+        Review the resolver report and raise an exception if there
+        are any phantoms.
         """
 
-        if len(self.missing_report.missing) > 0:
+        phantoms = self.resolver_report.phantoms_keys()
+        if len(phantoms) > 0 and not self.skip_phantoms:
             self.state = WorkflowState.FAILED
-            raise WorkflowMissingObjectsError(
-                f"Missing {len(self.missing_report.missing)} objects",
-                self.missing_report)
+            raise WorkflowPhantomsError(
+                f"Phantoms objects: {len(phantoms)}",
+                self.resolver_report)
 
 
     def run_processing(self):
-        yield self.state_change(WorkflowState.CONNECTED,
+        yield self.state_change(WorkflowState.RESOLVED,
                                 WorkflowState.PROCESSING)
-
-        missing_report = self.resolver.report()
-        if missing_report.missing:
-            missing_processor = DiffOnlyProcessor(
-                koji_session=self.session,
-                dataseries=missing_report.missing.values(),  # type: ignore
-                resolver=self.resolver,
-                chunk_size=self.chunk_size
-            )
-            missing_processor.run()
-            missing_report = self.resolver.report()
-
-        self.missing_report = missing_report
-        self.review_missing_report()
 
         self.processor = self.cls_processor(
             koji_session=self.session,
             dataseries=self.dataseries,
             resolver=self.resolver,
-            chunk_size=self.chunk_size
+            chunk_size=self.chunk_size,
+            skip_phantoms=self.skip_phantoms
         )
         self.summary = self.processor.run(self.processor_step_callback)
         yield self.state_change(WorkflowState.PROCESSING,
@@ -231,6 +234,7 @@ class Workflow:
         yield from self.run_loading()
         yield from self.run_solving()
         yield from self.run_connecting()
+        yield from self.run_resolving()
         yield from self.run_processing()
         yield self.state_change(WorkflowState.PROCESSED,
                                 WorkflowState.COMPLETED)
@@ -345,9 +349,10 @@ class SyncWorkflow(Workflow):
             paths: List[str | Path],
             template_paths: List[str | Path] = None,
             profile: str = 'koji',
-            chunk_size: int = 100):
+            chunk_size: int = 100,
+            skip_phantoms: bool = False):
 
-        super().__init__(paths, template_paths, profile, chunk_size)
+        super().__init__(paths, template_paths, profile, chunk_size, skip_phantoms)
 
 
 class DiffWorkflow(Workflow):
@@ -357,17 +362,17 @@ class DiffWorkflow(Workflow):
             paths: List[str | Path],
             template_paths: List[str | Path] = None,
             profile: str = 'koji',
-            chunk_size: int = 100):
+            chunk_size: int = 100,
+            skip_phantoms: bool = False):
 
         super().__init__(
-            paths, template_paths, profile, chunk_size,
+            paths, template_paths, profile, chunk_size, skip_phantoms,
             cls_processor=DiffOnlyProcessor)
 
 
-    def review_missing_report(self):
+    def review_resolver_report(self):
         """
-        Diff mode is allowed to have missing objects, so we don't need
-        to do anything.
+        Diff mode is allowed to have phantoms, so we don't need to do anything.
         """
 
         pass

--- a/tests/test_processor_models/test_tag.py
+++ b/tests/test_processor_models/test_tag.py
@@ -207,12 +207,16 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         add_external_repo_mock = Mock()
         add_external_repo_mock.return_value = None
 
+        set_permission_mock = Mock()
+        set_permission_mock.return_value = None
+
         self.queue_client_response('getTag', get_tag_mock)
         self.queue_client_response('listPackages', list_packages_mock)
         self.queue_client_response('getTagGroups', get_groups_mock)
         self.queue_client_response('getInheritanceData', get_inheritance_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos_mock)
         self.queue_client_response('createTag', create_mock)
+        self.queue_client_response('editTag2', set_permission_mock)
         self.queue_client_response('editTag2', set_extras_mock)
         self.queue_client_response('groupListAdd', add_group_mock)
         self.queue_client_response('groupPackageListAdd', add_group_pkg1_mock)
@@ -243,6 +247,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         get_inheritance_mock.assert_not_called()
         get_external_repos_mock.assert_not_called()
         create_mock.assert_called_once()
+        set_permission_mock.assert_called_once_with('complex-tag', perm='admin')
         set_extras_mock.assert_called_once_with('complex-tag', extra={'key': 'value'})
         add_group_mock.assert_called_once_with('complex-tag', 'build', description=None, block=False, force=True)
         add_group_pkg1_mock.assert_called_once_with('complex-tag', 'build', 'package1', block=False, force=True)
@@ -589,6 +594,9 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         set_extras2_mock = Mock()
         set_extras2_mock.return_value = None
 
+        set_permission2_mock = Mock()
+        set_permission2_mock.return_value = None
+
         # Queue responses for both tags
         self.queue_client_response('getTag', get_tag1_mock)
         self.queue_client_response('getTagGroups', get_groups1_mock)
@@ -602,6 +610,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.queue_client_response('getInheritanceData', get_inheritance2_mock)
         self.queue_client_response('getTagExternalRepos', get_external_repos2_mock)
         self.queue_client_response('createTag', create2_mock)
+        self.queue_client_response('editTag2', set_permission2_mock)
         self.queue_client_response('editTag2', set_extras2_mock)
 
         self.queue_client_response('getTag', get_tag_post1_mock)
@@ -629,6 +638,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         set_extras2_mock.assert_called_once_with('tag2', extra={})
         get_tag_post1_mock.assert_called_once_with('tag1', strict=False)
         get_tag_post2_mock.assert_called_once_with('tag2', strict=False)
+        set_permission2_mock.assert_called_once_with('tag2', perm='admin')
 
 
 class TestProcessorTagGroups(MulticallMocking, TestCase):
@@ -1352,7 +1362,6 @@ class TestProcessorTagDependencies(MulticallMocking, TestCase):
         create_parent_mock.assert_called_once_with(
             'parent-tag',
             locked=False,
-            perm=None,
             arches='x86_64',
             maven_support=False,
             maven_include_all=False
@@ -1362,7 +1371,6 @@ class TestProcessorTagDependencies(MulticallMocking, TestCase):
         create_child_mock.assert_called_once_with(
             'child-tag',
             locked=False,
-            perm=None,
             arches='x86_64',
             maven_support=False,
             maven_include_all=False

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -245,7 +245,7 @@ class TestSolverBasic(unittest.TestCase):
 
         # Should return a report from the resolver
         self.assertIsNotNone(report)
-        self.assertIsInstance(report.missing, dict)
+        self.assertIsInstance(report.phantoms, dict)
 
     def test_solver_report_with_missing_dependencies(self):
         """Test solver report when there are missing dependencies."""
@@ -255,10 +255,10 @@ class TestSolverBasic(unittest.TestCase):
         report = solver.report()
 
         # Should report missing dependencies
-        self.assertGreater(len(report.missing), 0)
+        self.assertGreater(len(report.phantoms), 0)
 
         # Should contain expected missing dependencies
-        missing_keys = set(report.missing)
+        missing_keys = set(report.phantoms)
         expected_missing = {
             ('tag', 'missing-parent-tag'),
             ('tag', 'missing-build-tag'),
@@ -757,14 +757,14 @@ class TestSolverMissingDependencies(unittest.TestCase):
             ('external-repo', 'missing-external-repo')
         }
 
-        missing_set = set(report.missing)
+        missing_set = set(report.phantoms)
         self.assertEqual(missing_set, expected_missing)
 
         # After resolving, the report should still show the same missing dependencies
         resolved_objects = list(solver)
         report_after = solver.report()
 
-        self.assertEqual(set(report_after.missing), expected_missing)
+        self.assertEqual(set(report_after.phantoms), expected_missing)
 
     def test_missing_dependencies_no_failure(self):
         """Test that missing dependencies don't cause solver to fail."""
@@ -1089,12 +1089,12 @@ class TestSolverCircularDependencies(unittest.TestCase):
 
         # Should have no missing dependencies in this file
         report = solver.report()
-        self.assertEqual(len(report.missing), 0)
+        self.assertEqual(len(report.phantoms), 0)
 
         # After resolving, should still have no missing dependencies
         resolved_objects = list(solver)
         report_after = solver.report()
-        self.assertEqual(len(report_after.missing), 0)
+        self.assertEqual(len(report_after.phantoms), 0)
 
 
 class TestSolverTemplates(unittest.TestCase):
@@ -1261,12 +1261,12 @@ class TestSolverTemplates(unittest.TestCase):
 
         # Should only have the 2 implicit missing permissions
         report = solver.report()
-        self.assertEqual(len(report.missing), 2)
+        self.assertEqual(len(report.phantoms), 2)
 
         # After resolving, should still have the 2 implicit missing permissions
         resolved_objects = list(solver)
         report_after = solver.report()
-        self.assertEqual(len(report_after.missing), 2)
+        self.assertEqual(len(report_after.phantoms), 2)
 
     def test_template_based_dependencies_complex_workflow(self):
         """Test complex workflow with template-generated dependencies."""
@@ -1326,7 +1326,7 @@ class TestSolverIntegration(unittest.TestCase):
 
         # Should have no missing dependencies
         report = solver.report()
-        self.assertEqual(len(report.missing), 0)
+        self.assertEqual(len(report.phantoms), 0)
 
     def test_complete_workflow_mixed_dependencies(self):
         """Test complete workflow with mixed dependency types."""
@@ -1381,13 +1381,13 @@ class TestSolverIntegration(unittest.TestCase):
 
         # Should have missing dependencies before resolution
         report_before = solver.report()
-        self.assertEqual(len(report_before.missing), 6)
-        self.assertIn(('tag', 'missing-parent-tag'), report_before.missing)
-        self.assertIn(('tag', 'missing-build-tag'), report_before.missing)
-        self.assertIn(('tag', 'missing-dest-tag'), report_before.missing)
-        self.assertIn(('group', 'missing-group'), report_before.missing)
-        self.assertIn(('permission', 'missing-permission'), report_before.missing)
-        self.assertIn(('external-repo', 'missing-external-repo'), report_before.missing)
+        self.assertEqual(len(report_before.phantoms), 6)
+        self.assertIn(('tag', 'missing-parent-tag'), report_before.phantoms)
+        self.assertIn(('tag', 'missing-build-tag'), report_before.phantoms)
+        self.assertIn(('tag', 'missing-dest-tag'), report_before.phantoms)
+        self.assertIn(('group', 'missing-group'), report_before.phantoms)
+        self.assertIn(('permission', 'missing-permission'), report_before.phantoms)
+        self.assertIn(('external-repo', 'missing-external-repo'), report_before.phantoms)
 
         # Resolve all objects
         resolved_objects = list(solver)
@@ -1417,7 +1417,7 @@ class TestSolverIntegration(unittest.TestCase):
 
         # Should still have missing dependencies after resolution
         report_after = solver.report()
-        self.assertEqual(len(report_after.missing), 6)
+        self.assertEqual(len(report_after.phantoms), 6)
 
     def test_complete_workflow_circular_dependencies(self):
         """Test complete workflow with circular dependencies."""
@@ -1444,7 +1444,7 @@ class TestSolverIntegration(unittest.TestCase):
 
         # Should have no missing dependencies
         report = solver.report()
-        self.assertEqual(len(report.missing), 0)
+        self.assertEqual(len(report.phantoms), 0)
 
     def test_partial_workflow_complex_scenario(self):
         """Test partial workflow with specific work items from complex scenario."""
@@ -1496,7 +1496,7 @@ class TestSolverIntegration(unittest.TestCase):
 
         # Should have missing dependencies before resolution
         report_before = solver.report()
-        self.assertEqual(len(report_before.missing), 6)
+        self.assertEqual(len(report_before.phantoms), 6)
 
         # Resolve all objects
         resolved_objects = list(solver)
@@ -1534,7 +1534,7 @@ class TestSolverIntegration(unittest.TestCase):
 
         # Should still have missing dependencies after resolution
         report_after = solver.report()
-        self.assertEqual(len(report_after.missing), 6)
+        self.assertEqual(len(report_after.phantoms), 6)
 
     def test_workflow_error_handling(self):
         """Test workflow error handling and edge cases."""
@@ -1556,8 +1556,8 @@ class TestSolverIntegration(unittest.TestCase):
 
         # Should have missing dependency
         report = solver.report()
-        self.assertEqual(len(report.missing), 1)
-        self.assertIn(('tag', 'nonexistent'), report.missing)
+        self.assertEqual(len(report.phantoms), 1)
+        self.assertIn(('tag', 'nonexistent'), report.phantoms)
 
     def test_workflow_consistency_across_runs(self):
         """Test that workflow produces consistent results across multiple runs."""
@@ -1582,14 +1582,14 @@ class TestSolverIntegration(unittest.TestCase):
 
         # Get report before resolution
         report_before = solver.report()
-        missing_before = set(report_before.missing)
+        missing_before = set(report_before.phantoms)
 
         # Resolve objects
         resolved_objects = list(solver)
 
         # Get report after resolution
         report_after = solver.report()
-        missing_after = set(report_after.missing)
+        missing_after = set(report_after.phantoms)
 
         # Missing dependencies should be the same
         self.assertEqual(missing_before, missing_after,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -15,9 +15,6 @@ from pathlib import Path
 from typing import List, Any, Dict
 
 from koji_habitude.workflow import SyncWorkflow, WorkflowState
-from koji_habitude.models import Base
-from koji_habitude.processor import ProcessorSummary
-from koji_habitude.resolver import Report
 from tests.test_processor_models import MulticallMocking, create_resolver_with_objects
 
 


### PR DESCRIPTION
## Summary

This PR adds a new `--skip-phantoms` flag to the sync CLI command that allows users to skip objects that are phantoms (objects that don't exist in the koji hub but are referenced in the local data).

## Key Changes

### New Features
- Added `--skip-phantoms` CLI flag to `koji-habitude sync` command
- Implemented `is_phantom()` method in `BaseObject` class
- Added `skip_phantoms` parameter to `Workflow` class
- Enhanced error handling for phantom objects with `WorkflowPhantomsError`

### Code Improvements
- Refactored phantom detection logic with dedicated `is_phantom()` method
- Improved error handling for `MultiCallNotReady` exceptions
- Updated resolver and workflow classes to handle phantom skipping
- Enhanced CLI utilities with better error reporting

### Testing
- Updated tests to accommodate new phantom handling
- Added test coverage for skip-phantoms functionality

## Files Modified
- `koji_habitude/cli/sync.py` - Added skip-phantoms CLI option
- `koji_habitude/models/base.py` - Added is_phantom() method and improved error handling
- `koji_habitude/workflow.py` - Added skip_phantoms support and WorkflowPhantomsError
- `koji_habitude/resolver.py` - Enhanced phantom detection and reporting
- Multiple model files - Added phantom detection support
- Test files - Updated to work with new phantom handling

## Usage
```bash
koji-habitude sync --skip-phantoms /path/to/data
```

This allows users to synchronize their local koji data while skipping any phantom objects that don't exist in the target koji hub, preventing sync failures due to missing dependencies.

## Commits
- 78bf02d: wip on fixing nomenclature for phantoms, and adding skip_phantoms support
- 768e632: fixing imports and tests with the new names  
- 5833d0d: just echo, sheesh
- c1fb289: tweaks
- 2a7e38c: some more renames
- 1ed870a: the resolver isn't its report
- 933171f: the resolver isn't its report
- c9b9451: skippable changes
- a4e2992: skip-phantoms in the sync cli
- c79e651: remove useless logging
- 586e123: update tests for split out permission setting
- 8f411ed: switch to a dedicated is_phantom method
- b964ae4: have to adjust tag's break_multical logic slightly
- e0befd0: just a cheeky assert