### PR TITLE
Add discrete extras management with blocking support

### DIFF
--- a/tests/test_processor_models/test_tag.py
+++ b/tests/test_processor_models/test_tag.py
@@ -134,8 +134,8 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertTrue(result)  # Should process 1 object
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('new-tag', strict=False)
-        get_tag_post_mock.assert_called_once_with('new-tag', strict=False)
+        get_tag_mock.assert_called_once_with('new-tag', strict=False, blocked=True)
+        get_tag_post_mock.assert_called_once_with('new-tag', strict=False, blocked=True)
         # When tag doesn't exist, deferred calls are not made
         list_packages_mock.assert_not_called()
         get_groups_mock.assert_not_called()
@@ -235,8 +235,8 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         # Verify all calls were made
-        get_tag_mock.assert_called_once_with('complex-tag', strict=False)
-        get_tag_post_mock.assert_called_once_with('complex-tag', strict=False)
+        get_tag_mock.assert_called_once_with('complex-tag', strict=False, blocked=True)
+        get_tag_post_mock.assert_called_once_with('complex-tag', strict=False, blocked=True)
         # When tag doesn't exist, deferred calls are not made
         list_packages_mock.assert_not_called()
         get_groups_mock.assert_not_called()
@@ -315,7 +315,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         set_locked_mock.assert_called_once_with('existing-tag', locked=True)
 
     def test_update_permission(self):
@@ -371,7 +371,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         set_permission_mock.assert_called_once_with('existing-tag', perm='admin')
 
     def test_update_arches(self):
@@ -427,7 +427,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         set_arches_mock.assert_called_once_with('existing-tag', arches='x86_64 aarch64')
 
     def test_update_maven_settings(self):
@@ -483,7 +483,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         set_maven_mock.assert_called_once_with('existing-tag', maven_support=True, maven_include_all=True)
 
     def test_no_changes_needed(self):
@@ -534,7 +534,7 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertTrue(result)  # Should process 1 object
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         get_inheritance_mock.assert_called_once_with('existing-tag')
@@ -622,12 +622,12 @@ class TestProcessorTagLifecycle(MulticallMocking, TestCase):
         self.assertEqual(summary.state, ProcessorState.EXHAUSTED)
 
         # Verify all calls were made
-        get_tag1_mock.assert_called_once_with('tag1', strict=False)
-        get_tag2_mock.assert_called_once_with('tag2', strict=False)
+        get_tag1_mock.assert_called_once_with('tag1', strict=False, blocked=True)
+        get_tag2_mock.assert_called_once_with('tag2', strict=False, blocked=True)
         create1_mock.assert_called_once()
         create2_mock.assert_called_once()
-        get_tag_post1_mock.assert_called_once_with('tag1', strict=False)
-        get_tag_post2_mock.assert_called_once_with('tag2', strict=False)
+        get_tag_post1_mock.assert_called_once_with('tag1', strict=False, blocked=True)
+        get_tag_post2_mock.assert_called_once_with('tag2', strict=False, blocked=True)
         set_permission2_mock.assert_called_once_with('tag2', perm='admin')
 
 
@@ -695,7 +695,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertTrue(result)  # Should process 1 object
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         add_group_mock.assert_called_once_with('existing-tag', 'build', description=None, block=False, force=True)
@@ -760,7 +760,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertTrue(result)
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should update group because block status differs
@@ -827,7 +827,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertTrue(result)
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should remove the group because exact_groups=True and group not in desired state
@@ -892,7 +892,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertTrue(result)
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should add the missing package
@@ -957,7 +957,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertTrue(result)
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should update the package because block status differs
@@ -1027,7 +1027,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertTrue(result)
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
         # Should remove the extra package because exact_packages=True
@@ -1112,7 +1112,7 @@ class TestProcessorTagGroups(MulticallMocking, TestCase):
         self.assertTrue(result)
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
         get_groups_mock.assert_called_once_with('existing-tag', inherit=False, incl_blocked=True)
 
@@ -1188,7 +1188,7 @@ class TestProcessorTagDependencies(MulticallMocking, TestCase):
         self.assertTrue(result)  # Should process 1 object
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         add_inheritance_mock.assert_called_once()
 
     def test_add_external_repo(self):
@@ -1244,7 +1244,7 @@ class TestProcessorTagDependencies(MulticallMocking, TestCase):
         self.assertTrue(result)  # Should process 1 object
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         add_external_repo_mock.assert_called_once_with('existing-tag', 'external-repo', priority=5, merge_mode='koji', arches=None)
 
     def test_simultaneous_tag_creation_with_inheritance(self):
@@ -1448,7 +1448,7 @@ class TestProcessorTagPackages(MulticallMocking, TestCase):
         self.assertTrue(result)
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('existing-tag', strict=False)
+        get_tag_mock.assert_called_once_with('existing-tag', strict=False, blocked=True)
         list_packages_mock.assert_called_once_with(tagID='existing-tag')
         add_package_mock.assert_called_once_with(
             'existing-tag',
@@ -2071,7 +2071,7 @@ class TestProcessorTagPackages(MulticallMocking, TestCase):
         self.assertTrue(result)
         self.assertEqual(processor.state, ProcessorState.READY_CHUNK)
 
-        get_tag_mock.assert_called_once_with('new-tag', strict=False)
+        get_tag_mock.assert_called_once_with('new-tag', strict=False, blocked=True)
         create_mock.assert_called_once()
         # Verify both packages were added during creation
         add_package1_mock.assert_called_once_with(


### PR DESCRIPTION
## Summary

This PR implements granular extra field management for tags, moving from a simple "set all extras" approach to discrete field-by-field management with support for blocking inheritance of specific extra fields.

## Changes

### New Extra Field Management Classes
- `TagAddExtra` - Add a new extra field
- `TagUpdateExtra` - Update an existing extra field value  
- `TagRemoveExtra` - Remove an extra field
- `TagBlockExtra` - Block an extra field (prevent inheritance)
- `TagUnblockExtra` - Unblock an extra field

### Enhanced Tag Model
- Added `blocked_extras: List[str]` field to track blocked extra fields
- Added `exact_extras: bool` field to control whether extras should be exact matches
- Modified `RemoteTag.from_koji()` to handle blocked extras parsing from Koji's `[blocked, value]` format

### Improved Extra Field Comparison Logic
- Replaced simple `TagSetExtras` with granular `_compare_extras()` method
- Now handles individual extra field additions, updates, and removals
- Supports blocking/unblocking extra fields
- Respects `exact_extras` flag for precise control

### Updated Koji API Calls
- Modified `query_remote()` to include `blocked=True` parameter for fetching blocked extra data
- Updated all test mocks to expect the new `blocked=True` parameter

### Documentation Updates
- Updated `docs/yaml_format/tag.rst` to document new `blocked-extras` and `exact-extras` fields
- Added examples showing how to use the new extra field management features

## Technical Details

The changes implement a more sophisticated approach to managing tag extra fields:

1. **Granular Control**: Instead of replacing all extras at once, the system now manages individual fields
2. **Inheritance Blocking**: Specific extra fields can be blocked from inheritance to child tags
3. **Exact Matching**: Optional strict mode that removes undeclared extra fields
4. **Koji Integration**: Proper handling of Koji's blocked extras format `[blocked, value]`

## Testing

- All existing tests updated to work with new API calls
- Comprehensive test coverage for the new extra field management functionality
- Tests verify proper handling of blocked extras and exact matching behavior

## YAML Usage

```yaml
---
type: tag
name: my-tag
extras:
  description: "My tag description"
  build_requires: "special-build-requirements"

# List of extra fields that should be blocked from inheritance
blocked-extras:
  - sensitive-data
  - internal-notes

# Whether to enforce exact extras matching (removes undeclared extras)
exact-extras: false
```

Assisted-by: Claude 4.5 Sonnet via Cursor