### PR TITLE
Make recursive directory searching optional (default: non-recursive)

### DIFF
--- a/koji_habitude/cli/apply.py
+++ b/koji_habitude/cli/apply.py
@@ -32,6 +32,9 @@ class ApplyWorkflow(_ApplyWorkflow):
     '--templates', metavar='PATH', multiple=True,
     help="Location to find templates that are not available in DATA")
 @click.option(
+    '--recursive', '-r', is_flag=True, default=False,
+    help="Search template and data directories recursively")
+@click.option(
     '--profile', "-p", default='koji',
     help="Koji profile to use for connection")
 @click.option(
@@ -41,7 +44,9 @@ class ApplyWorkflow(_ApplyWorkflow):
     '--skip-phantoms', 'skip_phantoms', is_flag=True, default=False,
     help="Skip objects that have phantom dependencies")
 @catchall
-def apply(data, templates=None, profile='koji', show_unchanged=False, skip_phantoms=False):
+def apply(data, templates=None, recursive=False,
+          profile='koji',
+          show_unchanged=False, skip_phantoms=False):
     """
     Apply local koji data expectations onto the hub instance.
 
@@ -53,7 +58,9 @@ def apply(data, templates=None, profile='koji', show_unchanged=False, skip_phant
     """
 
     workflow = ApplyWorkflow(
-        data, templates,
+        data=data,
+        templates=templates,
+        recursive=recursive,
         profile=profile,
         skip_phantoms=skip_phantoms)
 

--- a/koji_habitude/cli/compare.py
+++ b/koji_habitude/cli/compare.py
@@ -22,13 +22,17 @@ from .util import catchall, display_resolver_report, display_summary
     '--templates', 'templates', metavar='PATH', multiple=True,
     help="Location to find templates that are not available in DATA")
 @click.option(
+    '--recursive', '-r', is_flag=True, default=False,
+    help="Search template and data directories recursively")
+@click.option(
     '--profile', "-p", default='koji',
     help="Koji profile to use for connection")
 @click.option(
     '--show-unchanged', 'show_unchanged', is_flag=True, default=False,
     help="Show objects that don't need any changes")
 @catchall
-def compare(data, templates=None, profile='koji', show_unchanged=False):
+def compare(data, templates=None, recursive=False,
+            profile='koji', show_unchanged=False):
     """
     Show what changes would be made without applying them.
 
@@ -39,6 +43,7 @@ def compare(data, templates=None, profile='koji', show_unchanged=False):
     workflow = CompareWorkflow(
         paths=data,
         template_paths=templates,
+        recursive=recursive,
         profile=profile)
     workflow.run()
 

--- a/koji_habitude/cli/expand.py
+++ b/koji_habitude/cli/expand.py
@@ -23,13 +23,17 @@ from .util import catchall, resplit
     '--templates', 'templates', metavar='PATH', multiple=True,
     help="Location to find templates that are not available in DATA")
 @click.option(
+    '--recursive', '-r', is_flag=True, default=False,
+    help="Search template and data directories recursively")
+@click.option(
     '--validate', 'validate', is_flag=True, default=False,
     help="Validate the expanded templates and data files")
 @click.option(
     "--select", "-S", "select", metavar="NAME", multiple=True,
     help="Filter results to only include types")
 @catchall
-def expand(data, templates=None, validate=False, select=[]):
+def expand(data, templates=None, recursive=False,
+           validate=False, select=[]):
     """
     Expand templates and data files into YAML output.
 
@@ -49,13 +53,13 @@ def expand(data, templates=None, validate=False, select=[]):
     # Load templates into TemplateNamespace
     template_ns = TemplateNamespace()
     if templates:
-        template_ns.feedall_raw(load_yaml_files(templates))
+        template_ns.feedall_raw(load_yaml_files(templates, recursive=recursive))
         template_ns.expand()
 
     namespace.merge_templates(template_ns)
 
     # Load and process data files
-    namespace.feedall_raw(load_yaml_files(data))
+    namespace.feedall_raw(load_yaml_files(data, recursive=recursive))
     namespace.expand()
 
     select = resplit(select)

--- a/koji_habitude/cli/fetch.py
+++ b/koji_habitude/cli/fetch.py
@@ -26,6 +26,9 @@ from .util import catchall, sort_objects_for_output
     '--templates', 'templates', metavar='PATH', multiple=True,
     help="Location to find templates that are not available in DATA")
 @click.option(
+    '--recursive', '-r', is_flag=True, default=False,
+    help="Search template and data directories recursively")
+@click.option(
     '--profile', "-p", default='koji',
     help="Koji profile to use for connection")
 @click.option(
@@ -38,7 +41,8 @@ from .util import catchall, sort_objects_for_output
     "--show-unchanged", "-u", default=False, is_flag=True,
     help="Whether to show unchanged objects (bool default: False)")
 @catchall
-def fetch(data, templates, profile='koji', output=sys.stdout,
+def fetch(data, templates, recursive=False,
+          profile='koji', output=sys.stdout,
           include_defaults=False, show_unchanged=False):
     """
     Fetch remote data from Koji instance and output as YAML.
@@ -57,6 +61,7 @@ def fetch(data, templates, profile='koji', output=sys.stdout,
     workflow = CompareWorkflow(
         paths=data,
         template_paths=templates,
+        recursive=recursive,
         profile=profile)
     workflow.run()
 

--- a/koji_habitude/cli/templates.py
+++ b/koji_habitude/cli/templates.py
@@ -90,6 +90,9 @@ def print_template(tmpl: Template, full: bool = False, theme=None):
     '--templates', "-T", 'template_dirs', metavar='PATH', multiple=True,
     help="Load only templates from the given paths")
 @click.option(
+    '--recursive', '-r', is_flag=True, default=False,
+    help="Search template and data directories recursively")
+@click.option(
     '--yaml', 'yaml', is_flag=True, default=False,
     help="Show expanded templates as yaml")
 @click.option(
@@ -102,6 +105,7 @@ def print_template(tmpl: Template, full: bool = False, theme=None):
 def list_templates(
         dirs=[],
         template_dirs=[],
+        recursive=False,
         yaml=False,
         full=False,
         select=[]):
@@ -121,9 +125,9 @@ def list_templates(
 
     ns = TemplateNamespace()
     if template_dirs:
-        ns.feedall_raw(load_yaml_files(template_dirs))
+        ns.feedall_raw(load_yaml_files(template_dirs, recursive=recursive))
     if dirs:
-        ns.feedall_raw(load_yaml_files(dirs))
+        ns.feedall_raw(load_yaml_files(dirs, recursive=recursive))
     ns.expand()
 
     if select:
@@ -158,6 +162,9 @@ def template():
     '--templates', '-T', 'template_dirs', metavar='PATH', multiple=True,
     help="Load only templates from the given paths")
 @click.option(
+    '--recursive', '-r', is_flag=True, default=False,
+    help="Search template and data directories recursively")
+@click.option(
     '--yaml', 'yaml', is_flag=True, default=False,
     help="Template definition as yaml")
 @click.option(
@@ -167,6 +174,7 @@ def template():
 def template_show(
         template_name,
         template_dirs=[],
+        recursive=False,
         yaml=False,
         full=False):
     """
@@ -180,7 +188,7 @@ def template_show(
         template_dirs = list(Path.cwd().glob('*.yml'))
         template_dirs.extend(Path.cwd().glob('*.yaml'))
 
-    tns.feedall_raw(load_yaml_files(template_dirs))
+    tns.feedall_raw(load_yaml_files(template_dirs, recursive=recursive))
     tns.expand()
 
     tmpl = tns.get_template(template_name)
@@ -203,11 +211,15 @@ def template_show(
     '--templates', '-T', 'template_dirs', metavar='PATH', multiple=True,
     help="Load templates from the given paths")
 @click.option(
+    '--recursive', '-r', is_flag=True, default=False,
+    help="Search template and data directories recursively")
+@click.option(
     '--validate', 'validate', is_flag=True, default=False,
     help="Validate the expanded template")
 @catchall
 def template_expand(
         template_name,
+        recursive=False,
         variables=[],
         template_dirs=[],
         validate=False):
@@ -222,7 +234,7 @@ def template_expand(
         template_dirs = list(Path.cwd().glob('*.yml'))
         template_dirs.extend(Path.cwd().glob('*.yaml'))
 
-    tns.feedall_raw(load_yaml_files(template_dirs))
+    tns.feedall_raw(load_yaml_files(template_dirs, recursive=recursive))
     tns.expand()
 
     ns = Namespace() if validate else ExpanderNamespace()
@@ -246,6 +258,9 @@ def template_expand(
     '--templates', '-T', 'template_dirs', metavar='PATH', multiple=True,
     help="Load templates from the given paths")
 @click.option(
+    '--recursive', '-r', is_flag=True, default=False,
+    help="Search template and data directories recursively")
+@click.option(
     '--profile', "-p", default='koji',
     help="Koji profile to use for connection")
 @click.option(
@@ -256,6 +271,7 @@ def template_compare(
         template_name,
         variables=[],
         template_dirs=[],
+        recursive=False,
         profile='koji',
         show_unchanged=False):
     """
@@ -275,6 +291,7 @@ def template_compare(
     workflow = CompareDictWorkflow(
         objects=[data],
         template_paths=template_dirs,
+        recursive=recursive,
         profile=profile,
     )
     workflow.run()
@@ -292,6 +309,9 @@ def template_compare(
     '--templates', '-T', 'template_dirs', metavar='PATH', multiple=True,
     help="Load templates from the given paths")
 @click.option(
+    '--recursive', '-r', is_flag=True, default=False,
+    help="Search template and data directories recursively")
+@click.option(
     '--profile', "-p", default='koji',
     help="Koji profile to use for connection")
 @click.option(
@@ -302,6 +322,7 @@ def template_apply(
         template_name,
         variables=[],
         template_dirs=[],
+        recursive=False,
         profile='koji',
         show_unchanged=False):
     """
@@ -321,6 +342,7 @@ def template_apply(
     workflow = ApplyDictWorkflow(
         objects=[data],
         template_paths=template_dirs,
+        recursive=recursive,
         profile=profile,
     )
     workflow.run()

--- a/koji_habitude/workflow.py
+++ b/koji_habitude/workflow.py
@@ -85,6 +85,7 @@ class Workflow:
 
     paths: List[Union[str, Path]] = None
     template_paths: List[Union[str, Path]] = None
+    recursive: bool = False
     profile: str = 'koji'
     chunk_size: int = 100
     skip_phantoms: bool = False
@@ -113,7 +114,7 @@ class Workflow:
 
     def load_yaml(self, paths: List[Union[str, Path]]) -> Iterator[Dict[str, Any]]:
         ml = self.cls_multiloader([self.cls_yamlloader])
-        return ml.load(paths)
+        return ml.load(paths, recursive=self.recursive)
 
 
     def load_templates(self, paths: List[Union[str, Path]]) -> TemplateNamespace:
@@ -348,6 +349,7 @@ class ApplyWorkflow(Workflow):
             self,
             paths: List[Union[str, Path]],
             template_paths: List[Union[str, Path]] = None,
+            recursive: bool = False,
             profile: str = 'koji',
             chunk_size: int = 100,
             skip_phantoms: bool = False):
@@ -355,6 +357,7 @@ class ApplyWorkflow(Workflow):
         super().__init__(
             paths=paths,
             template_paths=template_paths,
+            recursive=recursive,
             profile=profile,
             chunk_size=chunk_size,
             skip_phantoms=skip_phantoms)
@@ -366,6 +369,7 @@ class CompareWorkflow(Workflow):
             self,
             paths: List[Union[str, Path]],
             template_paths: List[Union[str, Path]] = None,
+            recursive: bool = False,
             profile: str = 'koji',
             chunk_size: int = 100,
             skip_phantoms: bool = False):
@@ -373,6 +377,7 @@ class CompareWorkflow(Workflow):
         super().__init__(
             paths=paths,
             template_paths=template_paths,
+            recursive=recursive,
             profile=profile,
             chunk_size=chunk_size,
             skip_phantoms=skip_phantoms,
@@ -417,12 +422,14 @@ class ApplyDictWorkflow(DictWorkflow):
             self,
             objects: List[Dict[str, Any]],
             template_paths: List[Union[str, Path]] = None,
+            recursive: bool = False,
             profile: str = 'koji',
             chunk_size: int = 100,
             skip_phantoms: bool = False):
         super().__init__(
             objects=objects,
             template_paths=template_paths,
+            recursive=recursive,
             profile=profile,
             chunk_size=chunk_size,
             skip_phantoms=skip_phantoms)
@@ -433,12 +440,14 @@ class CompareDictWorkflow(DictWorkflow):
             self,
             objects: List[Dict[str, Any]],
             template_paths: List[Union[str, Path]] = None,
+            recursive: bool = False,
             profile: str = 'koji',
             chunk_size: int = 100,
             skip_phantoms: bool = False):
         super().__init__(
             objects=objects,
             template_paths=template_paths,
+            recursive=recursive,
             profile=profile,
             chunk_size=chunk_size,
             skip_phantoms=skip_phantoms,


### PR DESCRIPTION
## Summary

This PR changes the default behavior of YAML file loading from recursive to non-recursive directory searching, while adding an optional `--recursive` flag to all CLI commands that need it.

## Changes Made

### Core Changes
- **`koji_habitude/loader.py`**: 
  - Added `recursive: bool = False` parameter to `find_files()`, `combine_find_files()`, and `MultiLoader.load()`
  - Changed default behavior from recursive to non-recursive file discovery
  - Updated `load_yaml_files()` to accept and pass through recursive parameter

### CLI Updates
All CLI commands that load YAML files now support the `--recursive` flag:
- **`apply`**: Added `--recursive` option for template and data directory searching
- **`compare`**: Added `--recursive` option for template and data directory searching  
- **`expand`**: Added `--recursive` option for template and data directory searching
- **`fetch`**: Added `--recursive` option for template and data directory searching
- **`templates`**: Added `--recursive` option for template directory searching

### Test Updates
- **`tests/test_loader.py`**: Updated failing tests to cover both recursive and non-recursive modes
  - Split `test_find_files_recursive` into recursive and non-recursive variants
  - Split `test_combine_mixed_paths` into recursive and non-recursive variants
  - Split `test_combine_multiple_directories` into recursive and non-recursive variants
  - Split `test_load_mixed_paths` into recursive and non-recursive variants

## Breaking Changes

**Default behavior change**: Directory searching is now non-recursive by default. Users who previously relied on recursive searching will need to add the `--recursive` flag to their commands.

## Migration Guide

For users who need recursive behavior:

```bash
# Before (implicitly recursive)
koji-habitude apply data/

# After (explicitly recursive)
koji-habitude apply --recursive data/
```

## Testing

- All 54 tests in `test_loader.py` pass
- Both recursive and non-recursive modes are thoroughly tested
- No linting errors introduced

## Impact

This change improves performance for the common case where users only want to process files in the immediate directory, while still providing recursive functionality when explicitly requested.

Assisted-by: Claude 4.5 Sonnet via Cursor